### PR TITLE
fixes and hoe update

### DIFF
--- a/common/src/main/java/org/vivecraft/gameplay/trackers/SwingTracker.java
+++ b/common/src/main/java/org/vivecraft/gameplay/trackers/SwingTracker.java
@@ -2,6 +2,7 @@ package org.vivecraft.gameplay.trackers;
 
 import java.util.List;
 
+import net.minecraft.world.level.block.*;
 import org.vivecraft.ClientDataHolder;
 import org.vivecraft.api.Vec3History;
 import org.vivecraft.provider.ControllerType;
@@ -27,9 +28,6 @@ import net.minecraft.world.item.ShearsItem;
 import net.minecraft.world.item.SwordItem;
 import net.minecraft.world.item.TridentItem;
 import net.minecraft.world.level.ClipContext;
-import net.minecraft.world.level.block.LadderBlock;
-import net.minecraft.world.level.block.NoteBlock;
-import net.minecraft.world.level.block.VineBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
@@ -253,10 +251,14 @@ public class SwingTracker extends Tracker
                         {
                             int j = 3;
 
-                            if (item instanceof HoeItem)
+                            if (item instanceof HoeItem && (
+                                    blockstate.getBlock() instanceof CropBlock
+                                    || blockstate.getBlock() instanceof StemBlock
+                                    || blockstate.getBlock() instanceof AttachedStemBlock
+                                    || this.mc.gameMode.useItemOn(player, (ClientLevel)player.level, i == 0 ? InteractionHand.MAIN_HAND : InteractionHand.OFF_HAND, blockhitresult1).shouldSwing()))
                             {
+                                // don't try to break crops with hoes
                                 //this.mc.physicalGuiManager.preClickAction();
-                                this.mc.gameMode.useItemOn(player, (ClientLevel)player.level, i == 0 ? InteractionHand.MAIN_HAND : InteractionHand.OFF_HAND, blockhitresult1);
                             }
                             else if (blockstate.getBlock() instanceof NoteBlock)
                             {

--- a/common/src/main/java/org/vivecraft/mixin/client/renderer/entity/FishingHookRendererVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/renderer/entity/FishingHookRendererVRMixin.java
@@ -25,7 +25,7 @@ public class FishingHookRendererVRMixin {
     }
 
     @ModifyVariable(at = @At(value = "STORE", ordinal = 1),
-            method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", index = 25, print = true)
+            method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", index = 25)
     private double fishingLineStartX(double value) {
         int j = 1;
         if (currentlyRenderingFishingHook.getPlayerOwner().getMainHandItem().getItem() instanceof FishingRodItem)
@@ -38,17 +38,17 @@ public class FishingHookRendererVRMixin {
         return CachedHandPos.x;
     }
     @ModifyVariable(at = @At(value = "STORE", ordinal = 1),
-            method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", index = 27, print = true)
+            method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", index = 27)
     private double fishingLineStartY(double value) {
         return CachedHandPos.y;
     }
     @ModifyVariable(at = @At(value = "STORE", ordinal = 1),
-            method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", index = 29, print = true)
+            method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", index = 29)
     private double fishingLineStartZ(double value) {
         return CachedHandPos.z;
     }
     @ModifyVariable(at = @At(value = "STORE", ordinal = 1),
-            method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", index = 31, print = true)
+            method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", index = 31)
     private float fishingLineStartOffset(float value) {
         return 0.0F;
     }

--- a/common/src/main/java/org/vivecraft/mixin/client/renderer/entity/FishingHookRendererVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/renderer/entity/FishingHookRendererVRMixin.java
@@ -1,42 +1,55 @@
 package org.vivecraft.mixin.client.renderer.entity;
 
-import org.vivecraft.ClientDataHolder;
-import org.vivecraft.extensions.GameRendererExtension;
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.blaze3d.vertex.VertexConsumer;
-import com.mojang.math.Matrix3f;
-import com.mojang.math.Matrix4f;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.entity.FishingHookRenderer;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.FishingHook;
+import org.spongepowered.asm.mixin.injection.*;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.entity.FishingHookRenderer;
 import net.minecraft.world.item.FishingRodItem;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import org.vivecraft.ClientDataHolder;
+import org.vivecraft.extensions.GameRendererExtension;
 
 @Mixin(FishingHookRenderer.class)
 public class FishingHookRendererVRMixin {
 
-    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;getEyeHeight()F"), method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", locals = LocalCapture.CAPTURE_FAILHARD)
-    public void updateX(FishingHook fishingHook, float f, float g, PoseStack poseStack, MultiBufferSource multiBufferSource, int i, CallbackInfo ci, Player player, PoseStack.Pose pose, Matrix4f matrix4f, Matrix3f matrix3f, VertexConsumer vertexConsumer, int j, ItemStack itemStack, float h, float k, float l, double d, double e, double m, double n, double o, double p, double q, float r) {
+    private FishingHook currentlyRenderingFishingHook;
+    private Vec3 CachedHandPos;
 
-        int index = 1;
+    @Inject(at = @At("HEAD"), method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V")
+    public void storeFishingHook(FishingHook fishingHook, float f, float g, PoseStack poseStack, MultiBufferSource multiBufferSource, int i, CallbackInfo ci){
+        currentlyRenderingFishingHook = fishingHook;
+    }
 
-        if (player.getMainHandItem().getItem() instanceof FishingRodItem) {
-            index = 0;
+    @ModifyVariable(at = @At(value = "STORE", ordinal = 1),
+            method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", index = 25, print = true)
+    private double fishingLineStartX(double value) {
+        int j = 1;
+        if (currentlyRenderingFishingHook.getPlayerOwner().getMainHandItem().getItem() instanceof FishingRodItem)
+        {
+            j = 0;
         }
-        Vec3 vec31 = ((GameRendererExtension)Minecraft.getInstance().gameRenderer).getControllerRenderPos(index);
-        Vec3 vec32 = ClientDataHolder.getInstance().vrPlayer.vrdata_world_render.getHand(index).getDirection();
-
-        o = vec31.x + vec32.x * (double)0.47F;
-        p = vec31.y + vec32.y * (double)0.47F;
-        q = vec31.z + vec32.z * (double)0.47F;
-        r = 0.0F;
+        Vec3 vec31 = ((GameRendererExtension) Minecraft.getInstance().gameRenderer).getControllerRenderPos(j);
+        Vec3 vec32 = ClientDataHolder.getInstance().vrPlayer.vrdata_world_render.getHand(j).getDirection();
+        CachedHandPos = vec31.add(vec32.multiply(0.47, 0.47, 0.47));
+        return CachedHandPos.x;
+    }
+    @ModifyVariable(at = @At(value = "STORE", ordinal = 1),
+            method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", index = 27, print = true)
+    private double fishingLineStartY(double value) {
+        return CachedHandPos.y;
+    }
+    @ModifyVariable(at = @At(value = "STORE", ordinal = 1),
+            method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", index = 29, print = true)
+    private double fishingLineStartZ(double value) {
+        return CachedHandPos.z;
+    }
+    @ModifyVariable(at = @At(value = "STORE", ordinal = 1),
+            method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", index = 31, print = true)
+    private float fishingLineStartOffset(float value) {
+        return 0.0F;
     }
 }

--- a/common/src/main/java/org/vivecraft/modCompatMixin/irisMixin/IrisBeginFrameHack.java
+++ b/common/src/main/java/org/vivecraft/modCompatMixin/irisMixin/IrisBeginFrameHack.java
@@ -1,4 +1,4 @@
-package org.vivecraft.irisMixin;
+package org.vivecraft.modCompatMixin.irisMixin;
 
 import org.vivecraft.ClientDataHolder;
 import org.spongepowered.asm.mixin.Mixin;

--- a/common/src/main/java/org/vivecraft/modCompatMixin/irisMixin/IrisDeferredWorldRenderingPipelineVRMixin.java
+++ b/common/src/main/java/org/vivecraft/modCompatMixin/irisMixin/IrisDeferredWorldRenderingPipelineVRMixin.java
@@ -1,4 +1,4 @@
-package org.vivecraft.irisMixin;
+package org.vivecraft.modCompatMixin.irisMixin;
 
 import net.coderbot.iris.pipeline.DeferredWorldRenderingPipeline;
 import org.spongepowered.asm.mixin.Mixin;

--- a/common/src/main/java/org/vivecraft/modCompatMixin/irisMixin/IrisHandRendererVRMixin.java
+++ b/common/src/main/java/org/vivecraft/modCompatMixin/irisMixin/IrisHandRendererVRMixin.java
@@ -1,4 +1,4 @@
-package org.vivecraft.irisMixin;
+package org.vivecraft.modCompatMixin.irisMixin;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.coderbot.iris.pipeline.HandRenderer;

--- a/common/src/main/java/org/vivecraft/modCompatMixin/irisMixin/IrisNewWorldRenderingPipelineVRMixin.java
+++ b/common/src/main/java/org/vivecraft/modCompatMixin/irisMixin/IrisNewWorldRenderingPipelineVRMixin.java
@@ -1,4 +1,4 @@
-package org.vivecraft.irisMixin;
+package org.vivecraft.modCompatMixin.irisMixin;
 
 import org.vivecraft.ClientDataHolder;
 import net.coderbot.iris.mixin.LevelRendererAccessor;

--- a/common/src/main/java/org/vivecraft/modCompatMixin/irisMixin/IrisShadowRendererMixin.java
+++ b/common/src/main/java/org/vivecraft/modCompatMixin/irisMixin/IrisShadowRendererMixin.java
@@ -1,4 +1,4 @@
-package org.vivecraft.irisMixin;
+package org.vivecraft.modCompatMixin.irisMixin;
 
 import jdk.jfr.Percentage;
 import org.spongepowered.asm.mixin.Pseudo;

--- a/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiArrowWidgetMixin.java
+++ b/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiArrowWidgetMixin.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(targets = {"me.shedaniel.rei.impl.client.gui.widget.basewidgets.ArrowWidget"})
 public class reiArrowWidgetMixin {
 
-    @Inject(method = "renderBackground(Lcom/mojang/blaze3d/vertex/PoseStack;ZF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;blendFunc(II)V", shift = At.Shift.AFTER, remap = true), remap = false)
+    @Inject(method = "renderBackground(Lcom/mojang/blaze3d/vertex/PoseStack;ZF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;blendFunc(II)V", shift = At.Shift.AFTER))
     private void changeBlendFunction(CallbackInfo ci) {
         RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA,
                 GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,

--- a/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiArrowWidgetMixin.java
+++ b/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiArrowWidgetMixin.java
@@ -1,0 +1,21 @@
+package org.vivecraft.modCompatMixin.reiMixin;
+
+import com.mojang.blaze3d.platform.GlStateManager;
+import com.mojang.blaze3d.systems.RenderSystem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Pseudo
+@Mixin(targets = {"me.shedaniel.rei.impl.client.gui.widget.basewidgets.ArrowWidget"})
+public class reiArrowWidgetMixin {
+
+    @Inject(method = "renderBackground(Lcom/mojang/blaze3d/vertex/PoseStack;ZF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;blendFunc(II)V", shift = At.Shift.AFTER, remap = true), remap = false)
+    private void changeBlendFunction(CallbackInfo ci) {
+        RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA,
+                GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,
+                GlStateManager.SourceFactor.ONE_MINUS_DST_ALPHA, GlStateManager.DestFactor.ONE);
+    }
+}

--- a/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiBurningFireWidgetMixin.java
+++ b/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiBurningFireWidgetMixin.java
@@ -1,0 +1,21 @@
+package org.vivecraft.modCompatMixin.reiMixin;
+
+import com.mojang.blaze3d.platform.GlStateManager;
+import com.mojang.blaze3d.systems.RenderSystem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Pseudo
+@Mixin(targets = {"me.shedaniel.rei.impl.client.gui.widget.basewidgets.BurningFireWidget"})
+public class reiBurningFireWidgetMixin {
+
+    @Inject(method = "renderBackground(Lcom/mojang/blaze3d/vertex/PoseStack;ZF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;blendFunc(II)V", shift = At.Shift.AFTER, remap = true), remap = false)
+    private void changeBlendFunction(CallbackInfo ci) {
+        RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA,
+                GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,
+                GlStateManager.SourceFactor.ONE_MINUS_DST_ALPHA, GlStateManager.DestFactor.ONE);
+    }
+}

--- a/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiBurningFireWidgetMixin.java
+++ b/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiBurningFireWidgetMixin.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(targets = {"me.shedaniel.rei.impl.client.gui.widget.basewidgets.BurningFireWidget"})
 public class reiBurningFireWidgetMixin {
 
-    @Inject(method = "renderBackground(Lcom/mojang/blaze3d/vertex/PoseStack;ZF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;blendFunc(II)V", shift = At.Shift.AFTER, remap = true), remap = false)
+    @Inject(method = "renderBackground(Lcom/mojang/blaze3d/vertex/PoseStack;ZF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;blendFunc(II)V", shift = At.Shift.AFTER))
     private void changeBlendFunction(CallbackInfo ci) {
         RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA,
                 GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,

--- a/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiButtonWidgetMixin.java
+++ b/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiButtonWidgetMixin.java
@@ -1,0 +1,21 @@
+package org.vivecraft.modCompatMixin.reiMixin;
+
+import com.mojang.blaze3d.platform.GlStateManager;
+import com.mojang.blaze3d.systems.RenderSystem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Pseudo
+@Mixin(targets = {"me.shedaniel.rei.impl.client.gui.widget.basewidgets.ButtonWidget"})
+public class reiButtonWidgetMixin {
+
+    @Inject(method = "renderBackground(Lcom/mojang/blaze3d/vertex/PoseStack;IIIIIZLme/shedaniel/math/Color;)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;blendFunc(II)V", shift = At.Shift.AFTER, remap = true), remap = false)
+    private void changeBlendFunction(CallbackInfo ci) {
+        RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA,
+                GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,
+                GlStateManager.SourceFactor.ONE_MINUS_DST_ALPHA, GlStateManager.DestFactor.ONE);
+    }
+}

--- a/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiButtonWidgetMixin.java
+++ b/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiButtonWidgetMixin.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(targets = {"me.shedaniel.rei.impl.client.gui.widget.basewidgets.ButtonWidget"})
 public class reiButtonWidgetMixin {
 
-    @Inject(method = "renderBackground(Lcom/mojang/blaze3d/vertex/PoseStack;IIIIIZLme/shedaniel/math/Color;)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;blendFunc(II)V", shift = At.Shift.AFTER, remap = true), remap = false)
+    @Inject(method = "renderBackground(Lcom/mojang/blaze3d/vertex/PoseStack;IIIIIZLme/shedaniel/math/Color;)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;blendFunc(II)V", shift = At.Shift.AFTER))
     private void changeBlendFunction(CallbackInfo ci) {
         RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA,
                 GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,

--- a/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiEntryWidgetMixin.java
+++ b/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiEntryWidgetMixin.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(targets = {"me.shedaniel.rei.impl.client.gui.widget.EntryWidget"})
 public class reiEntryWidgetMixin {
 
-    @Inject(method = "drawBackground(Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;blendFunc(II)V", shift = At.Shift.AFTER, remap = true), remap = false)
+    @Inject(method = "drawBackground(Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;blendFunc(II)V", shift = At.Shift.AFTER))
     private void changeBlendFunction(CallbackInfo ci) {
         RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA,
                 GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,

--- a/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiEntryWidgetMixin.java
+++ b/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiEntryWidgetMixin.java
@@ -1,0 +1,21 @@
+package org.vivecraft.modCompatMixin.reiMixin;
+
+import com.mojang.blaze3d.platform.GlStateManager;
+import com.mojang.blaze3d.systems.RenderSystem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Pseudo
+@Mixin(targets = {"me.shedaniel.rei.impl.client.gui.widget.EntryWidget"})
+public class reiEntryWidgetMixin {
+
+    @Inject(method = "drawBackground(Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;blendFunc(II)V", shift = At.Shift.AFTER, remap = true), remap = false)
+    private void changeBlendFunction(CallbackInfo ci) {
+        RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA,
+                GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,
+                GlStateManager.SourceFactor.ONE_MINUS_DST_ALPHA, GlStateManager.DestFactor.ONE);
+    }
+}

--- a/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiPanelWidgetMixin.java
+++ b/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiPanelWidgetMixin.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(targets = {"me.shedaniel.rei.impl.client.gui.widget.basewidgets.PanelWidget"})
 public class reiPanelWidgetMixin {
 
-    @Inject(method = "renderBackground(Lcom/mojang/blaze3d/vertex/PoseStack;IIIIZFFFF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;blendFunc(II)V", shift = At.Shift.AFTER, remap = true), remap = false)
+    @Inject(method = "renderBackground(Lcom/mojang/blaze3d/vertex/PoseStack;IIIIZFFFF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;blendFunc(II)V", shift = At.Shift.AFTER))
     private void changeBlendFunction(CallbackInfo ci) {
         RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA,
                 GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,

--- a/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiPanelWidgetMixin.java
+++ b/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiPanelWidgetMixin.java
@@ -1,0 +1,21 @@
+package org.vivecraft.modCompatMixin.reiMixin;
+
+import com.mojang.blaze3d.platform.GlStateManager;
+import com.mojang.blaze3d.systems.RenderSystem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Pseudo
+@Mixin(targets = {"me.shedaniel.rei.impl.client.gui.widget.basewidgets.PanelWidget"})
+public class reiPanelWidgetMixin {
+
+    @Inject(method = "renderBackground(Lcom/mojang/blaze3d/vertex/PoseStack;IIIIZFFFF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;blendFunc(II)V", shift = At.Shift.AFTER, remap = true), remap = false)
+    private void changeBlendFunction(CallbackInfo ci) {
+        RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA,
+                GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,
+                GlStateManager.SourceFactor.ONE_MINUS_DST_ALPHA, GlStateManager.DestFactor.ONE);
+    }
+}

--- a/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiTabWidgetMixin.java
+++ b/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiTabWidgetMixin.java
@@ -1,0 +1,21 @@
+package org.vivecraft.modCompatMixin.reiMixin;
+
+import com.mojang.blaze3d.platform.GlStateManager;
+import com.mojang.blaze3d.systems.RenderSystem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Pseudo
+@Mixin(targets = {"me.shedaniel.rei.impl.client.gui.widget.TabWidget"})
+public class reiTabWidgetMixin {
+
+    @Inject(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;blendFunc(II)V", shift = At.Shift.AFTER, remap = true), remap = false)
+    private void changeBlendFunction(CallbackInfo ci) {
+        RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA,
+                GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,
+                GlStateManager.SourceFactor.ONE_MINUS_DST_ALPHA, GlStateManager.DestFactor.ONE);
+    }
+}

--- a/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiTabWidgetMixin.java
+++ b/common/src/main/java/org/vivecraft/modCompatMixin/reiMixin/reiTabWidgetMixin.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(targets = {"me.shedaniel.rei.impl.client.gui.widget.TabWidget"})
 public class reiTabWidgetMixin {
 
-    @Inject(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;blendFunc(II)V", shift = At.Shift.AFTER, remap = true), remap = false)
+    @Inject(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;blendFunc(II)V", shift = At.Shift.AFTER))
     private void changeBlendFunction(CallbackInfo ci) {
         RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA,
                 GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,

--- a/common/src/main/java/org/vivecraft/modCompatMixin/sodiumMixin/FabricSodiumGameOptionPagesVRMixin.java
+++ b/common/src/main/java/org/vivecraft/modCompatMixin/sodiumMixin/FabricSodiumGameOptionPagesVRMixin.java
@@ -1,7 +1,7 @@
-package org.vivecraft.sodiumMixin;
+package org.vivecraft.modCompatMixin.sodiumMixin;
 
+import org.vivecraft.ClientDataHolder;
 import me.jellysquid.mods.sodium.client.gui.SodiumGameOptionPages;
-import me.jellysquid.mods.sodium.client.gui.misc.GraphicsMode;
 import net.minecraft.client.GraphicsStatus;
 import net.minecraft.client.Options;
 import org.spongepowered.asm.mixin.Mixin;
@@ -9,14 +9,13 @@ import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.vivecraft.ClientDataHolder;
 
 @Pseudo
 @Mixin(SodiumGameOptionPages.class)
-public class ForgeSodiumGameOptionPagesVRMixin {
+public class FabricSodiumGameOptionPagesVRMixin {
 
     @Inject(at = @At("HEAD"), method = "lambda$quality$23", remap = false)
-    private static void initframe(Options opts, GraphicsMode value, CallbackInfo ci) {
+    private static void initframe(Options opts, GraphicsStatus value, CallbackInfo ci) {
         ClientDataHolder.getInstance().vrRenderer.reinitFrameBuffers("gfx setting change");
     }
 }

--- a/common/src/main/java/org/vivecraft/modCompatMixin/sodiumMixin/ForgeSodiumGameOptionPagesVRMixin.java
+++ b/common/src/main/java/org/vivecraft/modCompatMixin/sodiumMixin/ForgeSodiumGameOptionPagesVRMixin.java
@@ -1,7 +1,7 @@
-package org.vivecraft.sodiumMixin;
+package org.vivecraft.modCompatMixin.sodiumMixin;
 
-import org.vivecraft.ClientDataHolder;
 import me.jellysquid.mods.sodium.client.gui.SodiumGameOptionPages;
+import me.jellysquid.mods.sodium.client.gui.misc.GraphicsMode;
 import net.minecraft.client.GraphicsStatus;
 import net.minecraft.client.Options;
 import org.spongepowered.asm.mixin.Mixin;
@@ -9,13 +9,14 @@ import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.vivecraft.ClientDataHolder;
 
 @Pseudo
 @Mixin(SodiumGameOptionPages.class)
-public class FabricSodiumGameOptionPagesVRMixin {
+public class ForgeSodiumGameOptionPagesVRMixin {
 
     @Inject(at = @At("HEAD"), method = "lambda$quality$23", remap = false)
-    private static void initframe(Options opts, GraphicsStatus value, CallbackInfo ci) {
+    private static void initframe(Options opts, GraphicsMode value, CallbackInfo ci) {
         ClientDataHolder.getInstance().vrRenderer.reinitFrameBuffers("gfx setting change");
     }
 }

--- a/common/src/main/java/org/vivecraft/modCompatMixin/sodiumMixin/SodiumWorldRendererVRMixin.java
+++ b/common/src/main/java/org/vivecraft/modCompatMixin/sodiumMixin/SodiumWorldRendererVRMixin.java
@@ -1,4 +1,4 @@
-package org.vivecraft.sodiumMixin;
+package org.vivecraft.modCompatMixin.sodiumMixin;
 
 import me.jellysquid.mods.sodium.client.render.SodiumWorldRenderer;
 import org.spongepowered.asm.mixin.Mixin;

--- a/common/src/main/resources/vivecraft.fabric.sodium.mixins.json
+++ b/common/src/main/resources/vivecraft.fabric.sodium.mixins.json
@@ -1,6 +1,6 @@
 {
   "required": false,
-  "package": "org.vivecraft.sodiumMixin",
+  "package": "org.vivecraft.modCompatMixin.sodiumMixin",
   "plugin": "org.vivecraft.VRMixinConfig",
   "compatibilityLevel": "JAVA_17",
   "mixins": [

--- a/common/src/main/resources/vivecraft.forge.sodium.mixins.json
+++ b/common/src/main/resources/vivecraft.forge.sodium.mixins.json
@@ -1,6 +1,6 @@
 {
   "required": false,
-  "package": "org.vivecraft.sodiumMixin",
+  "package": "org.vivecraft.modCompatMixin.sodiumMixin",
   "plugin": "org.vivecraft.VRMixinConfig",
   "compatibilityLevel": "JAVA_17",
   "mixins": [

--- a/common/src/main/resources/vivecraft.iris.mixins.json
+++ b/common/src/main/resources/vivecraft.iris.mixins.json
@@ -1,6 +1,6 @@
 {
   "required": false,
-  "package": "org.vivecraft.irisMixin",
+  "package": "org.vivecraft.modCompatMixin.irisMixin",
   "plugin": "org.vivecraft.VRMixinConfig",
   "compatibilityLevel": "JAVA_17",
   "mixins": [

--- a/common/src/main/resources/vivecraft.rei.mixins.json
+++ b/common/src/main/resources/vivecraft.rei.mixins.json
@@ -1,0 +1,20 @@
+{
+  "required": false,
+  "package": "org.vivecraft.modCompatMixin.reiMixin",
+  "plugin": "org.vivecraft.VRMixinConfig",
+  "compatibilityLevel": "JAVA_17",
+  "mixins": [
+    "reiArrowWidgetMixin",
+    "reiButtonWidgetMixin",
+    "reiBurningFireWidgetMixin",
+    "reiTabWidgetMixin",
+    "reiPanelWidgetMixin",
+    "reiEntryWidgetMixin"
+  ],
+  "client": [
+
+  ],
+  "server": [
+  ],
+  "minVersion": "0.8.4"
+}

--- a/common/src/main/resources/vivecraft.sodium.mixins.json
+++ b/common/src/main/resources/vivecraft.sodium.mixins.json
@@ -1,6 +1,6 @@
 {
   "required": false,
-  "package": "org.vivecraft.sodiumMixin",
+  "package": "org.vivecraft.modCompatMixin.sodiumMixin",
   "plugin": "org.vivecraft.VRMixinConfig",
   "compatibilityLevel": "JAVA_17",
   "mixins": [

--- a/common/src/main/resources/vivecraft.vr.mixins.json
+++ b/common/src/main/resources/vivecraft.vr.mixins.json
@@ -37,6 +37,7 @@
     "client.renderer.ItemInHandRendererVRMixin",
     "client.renderer.entity.EntityRenderDispatcherVRMixin",
     "client.renderer.entity.EntityRendererVRMixin",
+    "client.renderer.entity.FishingHookRendererVRMixin",
     "client.renderer.entity.GuardianRendererVRMixin",
     "client.renderer.entity.MobRendererVRMixin",
     "client.renderer.NoSodiumLevelRendererVRMixin",

--- a/fabric/src/main/java/org/vivecraft/fabric/XeventsImpl.java
+++ b/fabric/src/main/java/org/vivecraft/fabric/XeventsImpl.java
@@ -1,10 +1,13 @@
 package org.vivecraft.fabric;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import dev.architectury.event.events.client.ClientGuiEvent;
+import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.state.BlockState;
+import org.vivecraft.Xplat;
 
 public class XeventsImpl {
 
@@ -29,6 +32,18 @@ public class XeventsImpl {
     }
 
     public static void drawScreen(Screen screen, PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
+        if (Xplat.isModLoaded("fabric")){
+            ScreenEvents.beforeRender(screen).invoker().beforeRender(screen, poseStack, mouseX, mouseY, partialTick);
+        }
+        if (Xplat.isModLoaded("architectury")){
+            ClientGuiEvent.RENDER_PRE.invoker().render(screen, poseStack, mouseX, mouseY, partialTick);
+        }
         screen.render(poseStack, mouseX, mouseY, partialTick);
+        if (Xplat.isModLoaded("fabric")){
+            ScreenEvents.afterRender(screen).invoker().afterRender(screen, poseStack, mouseX, mouseY, partialTick);
+        }
+        if (Xplat.isModLoaded("architectury")){
+            ClientGuiEvent.RENDER_POST.invoker().render(screen, poseStack, mouseX, mouseY, partialTick);
+        }
     }
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -18,6 +18,7 @@
     "vivecraft.sodium.mixins.json",
     "vivecraft.fabric.sodium.mixins.json",
     "vivecraft.iris.mixins.json",
+    "vivecraft.rei.mixins.json",
     "vivecraft.nonvr.fabric.mixins.json",
     "vivecraft.vr.fabric.mixins.json"
   ],

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -18,6 +18,7 @@ loom {
         mixinConfig "vivecraft.sodium.mixins.json"
         mixinConfig "vivecraft.forge.sodium.mixins.json"
         mixinConfig "vivecraft.iris.mixins.json"
+        mixinConfig "vivecraft.rei.mixins.json"
 
         mixinConfig "vivecraft.vr.forge.mixins.json"
         mixinConfig "vivecraft.nonvr.forge.mixins.json"


### PR DESCRIPTION
fix fishingline rendering
make hoes break blocks, when not tillable, or a crop
fix #35 , by calling fabric/architectury screen rendering calls.