### PR TITLE
fix native extraction on quilt 0.18

### DIFF
--- a/common/src/main/java/org/vivecraft/Xplat.java
+++ b/common/src/main/java/org/vivecraft/Xplat.java
@@ -55,4 +55,9 @@ public interface Xplat {
     static boolean enableRenderTargetStencil(RenderTarget renderTarget) {
         return false;
     }
+
+    @ExpectPlatform
+    static Path getJarPath(){
+        return null;
+    }
 }

--- a/common/src/main/java/org/vivecraft/utils/Utils.java
+++ b/common/src/main/java/org/vivecraft/utils/Utils.java
@@ -25,6 +25,8 @@ import java.util.Formatter;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -32,6 +34,7 @@ import javax.annotation.Nullable;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
+import org.vivecraft.Xplat;
 import org.vivecraft.render.VRShaders;
 import org.vivecraft.tweaker.LoaderUtils;
 import org.vivecraft.utils.lwjgl.Matrix3f;
@@ -454,22 +457,39 @@ public class Utils
             }
 
             System.out.println("Unpacking " + directory + " natives...");
-            ZipFile zipfile = LoaderUtils.getVivecraftZip();
-            Enumeration <? extends ZipEntry > enumeration = zipfile.entries();
 
-            while (enumeration.hasMoreElements())
+            Path jarPath = Xplat.getJarPath();
+            boolean didExtractSomething = false;
+            try (Stream<Path> natives = java.nio.file.Files.list(jarPath.resolve("natives/" + directory)))
             {
-                ZipEntry zipentry = enumeration.nextElement();
-
-                if (zipentry.getName().startsWith("natives/" + directory))
+                for (Path file : natives.collect(Collectors.toCollection(ArrayList::new)))
                 {
-                    String s = Paths.get(zipentry.getName()).getFileName().toString();
-                    System.out.println(s);
-                    writeStreamToFile(zipfile.getInputStream(zipentry), new File("openvr/" + directory + "/" + s));
+                    didExtractSomething = true;
+                    System.out.println(file);
+                    java.nio.file.Files.copy(file, new File("openvr/" + directory + "/" + file.getFileName()).toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
                 }
+            } catch (IOException e)
+            {
+                System.out.println("Failed to unpack natives from jar");
             }
+            if (!didExtractSomething) {
+                ZipFile zipfile = LoaderUtils.getVivecraftZip();
+                Enumeration <? extends ZipEntry > enumeration = zipfile.entries();
 
-            zipfile.close();
+                while (enumeration.hasMoreElements())
+                {
+                    ZipEntry zipentry = enumeration.nextElement();
+
+                    if (zipentry.getName().startsWith("natives/" + directory))
+                    {
+                        String s = Paths.get(zipentry.getName()).getFileName().toString();
+                        System.out.println(s);
+                        writeStreamToFile(zipfile.getInputStream(zipentry), new File("openvr/" + directory + "/" + s));
+                    }
+                }
+
+                zipfile.close();
+            }
         }
         catch (Exception exception1)
         {

--- a/fabric/src/main/java/org/vivecraft/fabric/XplatImpl.java
+++ b/fabric/src/main/java/org/vivecraft/fabric/XplatImpl.java
@@ -37,4 +37,8 @@ public class XplatImpl {
     public static boolean enableRenderTargetStencil(RenderTarget renderTarget) {
         return false;
     }
+
+    public static Path getJarPath(){
+        return FabricLoader.getInstance().getModContainer("vivecraft").get().getRootPaths().get(0);
+    }
 }

--- a/forge/src/main/java/org/vivecraft/forge/XplatImpl.java
+++ b/forge/src/main/java/org/vivecraft/forge/XplatImpl.java
@@ -40,4 +40,8 @@ public class XplatImpl {
         renderTarget.enableStencil();
         return true;
     }
+
+    public static Path getJarPath(){
+        return FMLLoader.getLoadingModList().getModFileById("vivecraft").getFile().getSecureJar().getPath("/");
+    }
 }


### PR DESCRIPTION
uses the jar provided by the modloader to extract the natives, and falls back to the old method, if that fails