### PR TITLE
use default GameRenderer.render method to render the screen

### DIFF
--- a/common/src/main/java/org/vivecraft/Xevents.java
+++ b/common/src/main/java/org/vivecraft/Xevents.java
@@ -34,10 +34,4 @@ public interface Xevents {
 
     }
 
-    @ExpectPlatform
-    public static void drawScreen(Screen screen, PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
-
-    }
-
-
 }

--- a/common/src/main/java/org/vivecraft/extensions/GameRendererExtension.java
+++ b/common/src/main/java/org/vivecraft/extensions/GameRendererExtension.java
@@ -44,8 +44,6 @@ public interface GameRendererExtension {
 
 	Matrix4f getThirdPassProjectionMatrix();
 
-	void drawFramebufferNEW(float f, boolean pRenderLevel, PoseStack poseStack);
-
 	void drawEyeStencil(boolean flag1);
 
 	float inBlock();

--- a/common/src/main/java/org/vivecraft/extensions/GameRendererExtension.java
+++ b/common/src/main/java/org/vivecraft/extensions/GameRendererExtension.java
@@ -61,4 +61,7 @@ public interface GameRendererExtension {
 	void setupRVE();
 
     void DrawScopeFB(PoseStack matrixStackIn, int i);
+
+	void setShouldDrawScreen(boolean shouldDrawScreen);
+	void setShouldDrawGui(boolean shouldDrawGui);
 }

--- a/common/src/main/java/org/vivecraft/mixin/client/MinecraftVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/MinecraftVRMixin.java
@@ -62,10 +62,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.vivecraft.*;
-import org.vivecraft.extensions.GameRendererExtension;
-import org.vivecraft.extensions.MinecraftExtension;
-import org.vivecraft.extensions.PlayerExtension;
-import org.vivecraft.extensions.RenderTargetExtension;
+import org.vivecraft.extensions.*;
 import org.vivecraft.api.ClientNetworkHelper;
 import org.vivecraft.gameplay.VRPlayer;
 import org.vivecraft.gameplay.screenhandlers.GuiHandler;
@@ -586,6 +583,12 @@ public abstract class MinecraftVRMixin extends ReentrantBlockableEventLoop<Runna
 		((GameRendererExtension) this.gameRenderer).setShouldDrawGui(bl && this.entityRenderDispatcher.camera != null);
 
 		this.gameRenderer.render(f, Util.getNanos(), false);
+		// draw cursor
+		if (Minecraft.getInstance().screen != null) {
+			int x = (int) (Minecraft.getInstance().mouseHandler.xpos() * (double) Minecraft.getInstance().getWindow().getGuiScaledWidth() / (double) Minecraft.getInstance().getWindow().getScreenWidth());
+			int y = (int) (Minecraft.getInstance().mouseHandler.ypos() * (double) Minecraft.getInstance().getWindow().getGuiScaledHeight() / (double) Minecraft.getInstance().getWindow().getScreenHeight());
+			((GuiExtension) Minecraft.getInstance().gui).drawMouseMenuQuad(x, y);
+		}
 		// draw debug pie
 		drawProfiler();
 

--- a/common/src/main/java/org/vivecraft/mixin/client/MinecraftVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/MinecraftVRMixin.java
@@ -582,7 +582,7 @@ public abstract class MinecraftVRMixin extends ReentrantBlockableEventLoop<Runna
 		// only draw the gui when the level was rendered once, since some mods expect that
 		((GameRendererExtension) this.gameRenderer).setShouldDrawGui(bl && this.entityRenderDispatcher.camera != null);
 
-		this.gameRenderer.render(f, Util.getNanos(), false);
+		this.gameRenderer.render(f, System.nanoTime(), false);
 		// draw cursor
 		if (Minecraft.getInstance().screen != null) {
 			int x = (int) (Minecraft.getInstance().mouseHandler.xpos() * (double) Minecraft.getInstance().getWindow().getGuiScaledWidth() / (double) Minecraft.getInstance().getWindow().getScreenWidth());

--- a/common/src/main/java/org/vivecraft/mixin/client/MinecraftVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/MinecraftVRMixin.java
@@ -1189,6 +1189,8 @@ public abstract class MinecraftVRMixin extends ReentrantBlockableEventLoop<Runna
 				if (itemstack.getItem() == Blocks.CARVED_PUMPKIN.asItem()
 						&& (!itemstack.hasTag() || itemstack.getTag().getInt("CustomModelData") == 0)) {
 					ClientDataHolder.getInstance().pumpkineffect = 1.0F;
+				} else {
+					ClientDataHolder.getInstance().pumpkineffect = 0.0F;
 				}
 
 				float hurtTimer = (float) this.player.hurtTime - nano;

--- a/common/src/main/java/org/vivecraft/mixin/client/MinecraftVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/MinecraftVRMixin.java
@@ -30,6 +30,7 @@ import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.renderer.FogRenderer;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.client.server.IntegratedServer;
 import net.minecraft.client.sounds.SoundManager;
@@ -283,6 +284,8 @@ public abstract class MinecraftVRMixin extends ReentrantBlockableEventLoop<Runna
 	public abstract void stop();
 
 	@Shadow @Final public LevelRenderer levelRenderer;
+
+	@Shadow @Final private EntityRenderDispatcher entityRenderDispatcher;
 
 	@Shadow private static Minecraft instance;
 
@@ -579,7 +582,8 @@ public abstract class MinecraftVRMixin extends ReentrantBlockableEventLoop<Runna
 		// draw screen/gui to buffer
 		RenderSystem.getModelViewStack().pushPose();
 		((GameRendererExtension) this.gameRenderer).setShouldDrawScreen(true);
-		((GameRendererExtension) this.gameRenderer).setShouldDrawGui(bl);
+		// only draw the gui when the level was rendered once, since some mods expect that
+		((GameRendererExtension) this.gameRenderer).setShouldDrawGui(bl && this.entityRenderDispatcher.camera != null);
 
 		this.gameRenderer.render(f, Util.getNanos(), false);
 		// draw debug pie

--- a/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
@@ -13,6 +13,7 @@ import com.mojang.math.Vector3f;
 import net.minecraft.Util;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.WinScreen;
 import net.minecraft.client.multiplayer.ClientLevel;
@@ -420,6 +421,20 @@ public abstract class GameRendererVRMixin
 
 	@Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/GameRenderer;renderItemActivationAnimation(IIF)V"), method = "render(FJZ)V")
 	private void noItemActivationAnimationOnGUI(GameRenderer instance, int i, int j, float f) {}
+	
+	@Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Gui;render(Lcom/mojang/blaze3d/vertex/PoseStack;F)V"), method = "render(FJZ)V")
+	private void noGUIwithViewOnly(Gui instance, PoseStack poseStack, float f) {
+		if (!ClientDataHolder.viewonly) {
+			instance.render(poseStack, f);
+		}
+	}
+
+	@Inject(at = @At("HEAD"), method = "renderConfusionOverlay", cancellable = true)
+	private void noConfusionOverlayOnGUI(float f, CallbackInfo ci) {
+		if (DATA_HOLDER.currentPass == RenderPass.GUI) {
+			ci.cancel();
+		}
+	}
 
 	@Redirect(method = "renderItemActivationAnimation", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;translate(DDD)V"))
 	private void noTranslateItem(PoseStack poseStack, double x, double y, double z){}

--- a/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
@@ -423,13 +423,13 @@ public abstract class GameRendererVRMixin
 	private void noItemActivationAnimationOnGUI(GameRenderer instance, int i, int j, float f) {}
 
 	@Group(name = "mouse cursor", min = 1, max = 1)
-	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;render(Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V", shift = Shift.AFTER), method = "render(FJZ)V", locals = LocalCapture.CAPTURE_FAILHARD)
+	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;render(Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V", shift = Shift.AFTER), method = "render(FJZ)V", locals = LocalCapture.CAPTURE_FAILHARD, expect = 0)
 	private void renderCursor(float f, long l, boolean bl, CallbackInfo ci, int x, int y) {
 		((GuiExtension) this.minecraft.gui).drawMouseMenuQuad(x, y);
 	}
 
 	@Group(name = "mouse cursor", min = 1, max = 1)
-	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraftforge/client/ForgeHooksClient;drawScreen(Lnet/minecraft/client/gui/screens/Screen;Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V", shift = Shift.AFTER), method = "render(FJZ)V", locals = LocalCapture.CAPTURE_FAILHARD)
+	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraftforge/client/ForgeHooksClient;drawScreen(Lnet/minecraft/client/gui/screens/Screen;Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V", shift = Shift.AFTER), method = "render(FJZ)V", locals = LocalCapture.CAPTURE_FAILHARD, expect = 0)
 	private void renderCursorForge(float f, long l, boolean bl, CallbackInfo ci, int x, int y) {
 		((GuiExtension) this.minecraft.gui).drawMouseMenuQuad(x, y);
 	}

--- a/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
@@ -2241,13 +2241,9 @@ public abstract class GameRendererVRMixin
 	private void renderVRSelfEffects(float par1) {
 		if (this.onfire && GameRendererVRMixin.DATA_HOLDER.currentPass != RenderPass.THIRD
 				&& GameRendererVRMixin.DATA_HOLDER.currentPass != RenderPass.CAMERA) {
-
-			if (this.onfire) {
-				this.renderFireInFirstPerson();
-			}
-
-			this.renderItemActivationAnimation(0, 0, par1);
+			this.renderFireInFirstPerson();
 		}
+		this.renderItemActivationAnimation(0, 0, par1);
 	}
 
 	private void renderFireInFirstPerson() {

--- a/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
@@ -56,7 +56,6 @@ import org.vivecraft.MethodHolder;
 import org.vivecraft.Xevents;
 import org.vivecraft.Xplat;
 import org.vivecraft.extensions.GameRendererExtension;
-import org.vivecraft.extensions.GuiExtension;
 import org.vivecraft.extensions.ItemInHandRendererExtension;
 import org.vivecraft.extensions.LevelRendererExtension;
 import org.vivecraft.extensions.PlayerExtension;
@@ -421,18 +420,6 @@ public abstract class GameRendererVRMixin
 
 	@Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/GameRenderer;renderItemActivationAnimation(IIF)V"), method = "render(FJZ)V")
 	private void noItemActivationAnimationOnGUI(GameRenderer instance, int i, int j, float f) {}
-
-	@Group(name = "mouse cursor", min = 1, max = 1)
-	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;render(Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V", shift = Shift.AFTER), method = "render(FJZ)V", locals = LocalCapture.CAPTURE_FAILHARD, expect = 0)
-	private void renderCursor(float f, long l, boolean bl, CallbackInfo ci, int x, int y) {
-		((GuiExtension) this.minecraft.gui).drawMouseMenuQuad(x, y);
-	}
-
-	@Group(name = "mouse cursor", min = 1, max = 1)
-	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraftforge/client/ForgeHooksClient;drawScreen(Lnet/minecraft/client/gui/screens/Screen;Lcom/mojang/blaze3d/vertex/PoseStack;IIF)V", shift = Shift.AFTER), method = "render(FJZ)V", locals = LocalCapture.CAPTURE_FAILHARD, expect = 0)
-	private void renderCursorForge(float f, long l, boolean bl, CallbackInfo ci, int x, int y) {
-		((GuiExtension) this.minecraft.gui).drawMouseMenuQuad(x, y);
-	}
 
 	@Redirect(method = "renderItemActivationAnimation", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;translate(DDD)V"))
 	private void noTranslateItem(PoseStack poseStack, double x, double y, double z){}

--- a/fabric/src/main/java/org/vivecraft/fabric/XeventsImpl.java
+++ b/fabric/src/main/java/org/vivecraft/fabric/XeventsImpl.java
@@ -31,19 +31,4 @@ public class XeventsImpl {
 
     }
 
-    public static void drawScreen(Screen screen, PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
-        if (Xplat.isModLoaded("fabric")){
-            ScreenEvents.beforeRender(screen).invoker().beforeRender(screen, poseStack, mouseX, mouseY, partialTick);
-        }
-        if (Xplat.isModLoaded("architectury")){
-            ClientGuiEvent.RENDER_PRE.invoker().render(screen, poseStack, mouseX, mouseY, partialTick);
-        }
-        screen.render(poseStack, mouseX, mouseY, partialTick);
-        if (Xplat.isModLoaded("fabric")){
-            ScreenEvents.afterRender(screen).invoker().afterRender(screen, poseStack, mouseX, mouseY, partialTick);
-        }
-        if (Xplat.isModLoaded("architectury")){
-            ClientGuiEvent.RENDER_POST.invoker().render(screen, poseStack, mouseX, mouseY, partialTick);
-        }
-    }
 }

--- a/forge/src/main/java/org/vivecraft/forge/XeventsImpl.java
+++ b/forge/src/main/java/org/vivecraft/forge/XeventsImpl.java
@@ -31,7 +31,4 @@ public class XeventsImpl {
         ForgeEventFactory.onRenderTickEnd(f);
     }
 
-    public static void drawScreen(Screen screen, PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
-        ForgeHooksClient.drawScreen(screen, poseStack, mouseX, mouseY, partialTick);
-    }
 }


### PR DESCRIPTION
uses the original default GameRenderer.render to render the screen, so mods can mix into it to make changes.

also fixes totem of undying rendering

fixes Xaeros World Map
fixes FancyMenu on fabric