### PR TITLE
some rendering fixes + other

### DIFF
--- a/common/src/main/java/org/vivecraft/gameplay/trackers/TelescopeTracker.java
+++ b/common/src/main/java/org/vivecraft/gameplay/trackers/TelescopeTracker.java
@@ -38,7 +38,7 @@ public class TelescopeTracker extends Tracker
 
     public static boolean isTelescope(ItemStack i)
     {
-        return i.getItem() == Items.SPYGLASS || isLegacyTelescope(i) || i.is(ItemTags.VIVECRAFT_TELESCOPE);
+        return i != null && (i.getItem() == Items.SPYGLASS || isLegacyTelescope(i) || i.is(ItemTags.VIVECRAFT_TELESCOPE));
     }
 
     // TODO: old eye of the farseer, remove this eventually

--- a/common/src/main/java/org/vivecraft/mixin/client/ClientBrandRetrieverVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/ClientBrandRetrieverVRMixin.java
@@ -8,7 +8,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(ClientBrandRetriever.class)
 public class ClientBrandRetrieverVRMixin {
-    @Inject(at = @At("RETURN"), method = "getClientModName", remap = false)
+    @Inject(at = @At("RETURN"), method = "getClientModName", remap = false, cancellable = true)
     private static void vivecraftClientBrand(CallbackInfoReturnable<String> cir) {
         cir.setReturnValue("vivecraft");
     }

--- a/common/src/main/java/org/vivecraft/mixin/client/ClientBrandRetrieverVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/ClientBrandRetrieverVRMixin.java
@@ -1,0 +1,15 @@
+package org.vivecraft.mixin.client;
+
+import net.minecraft.client.ClientBrandRetriever;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ClientBrandRetriever.class)
+public class ClientBrandRetrieverVRMixin {
+    @Inject(at = @At("RETURN"), method = "getClientModName", remap = false)
+    private static void vivecraftClientBrand(CallbackInfoReturnable<String> cir) {
+        cir.setReturnValue("vivecraft");
+    }
+}

--- a/common/src/main/java/org/vivecraft/mixin/client/ClientBrandRetrieverVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/ClientBrandRetrieverVRMixin.java
@@ -8,7 +8,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(ClientBrandRetriever.class)
 public class ClientBrandRetrieverVRMixin {
-    @Inject(at = @At("RETURN"), method = "getClientModName", remap = false, cancellable = true)
+    @Inject(at = @At("RETURN"), method = "getClientModName", cancellable = true)
     private static void vivecraftClientBrand(CallbackInfoReturnable<String> cir) {
         cir.setReturnValue("vivecraft");
     }

--- a/common/src/main/java/org/vivecraft/mixin/client/MinecraftVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/MinecraftVRMixin.java
@@ -439,6 +439,8 @@ public abstract class MinecraftVRMixin extends ReentrantBlockableEventLoop<Runna
 				ClientDataHolder.getInstance().vrRenderer.setupRenderConfiguration();
 			}
 			catch (RenderConfigException renderconfigexception) {
+				// unbind the rendertarget, to draw directly to the screen
+				this.mainRenderTarget.unbindWrite();
 				this.screen = null;
 				GlStateManager._viewport(0, 0, this.window.getScreenWidth(), this.window.getScreenHeight());
 

--- a/common/src/main/java/org/vivecraft/mixin/client/MinecraftVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/MinecraftVRMixin.java
@@ -653,7 +653,7 @@ public abstract class MinecraftVRMixin extends ReentrantBlockableEventLoop<Runna
 					this.mainRenderTarget = ClientDataHolder.getInstance().vrRenderer.cameraRenderFramebuffer;
 				}
 
-				this.profiler.push("Eye:" + ClientDataHolder.getInstance().currentPass.ordinal());
+				this.profiler.push("Eye:" + ClientDataHolder.getInstance().currentPass);
 				this.profiler.push("setup");
 				this.mainRenderTarget.bindWrite(true);
 				this.profiler.pop();

--- a/common/src/main/java/org/vivecraft/mixin/client/gui/GuiVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/gui/GuiVRMixin.java
@@ -1,5 +1,6 @@
 package org.vivecraft.mixin.client.gui;
 
+import net.minecraft.client.KeyMapping;
 import org.vivecraft.ClientDataHolder;
 import org.vivecraft.SodiumHelper;
 import org.vivecraft.Xplat;
@@ -12,7 +13,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiComponent;
-import net.minecraft.client.gui.components.PlayerTabOverlay;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.renderer.GameRenderer;
@@ -23,8 +23,6 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.scores.Objective;
-import net.minecraft.world.scores.Scoreboard;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -78,9 +76,9 @@ public abstract class GuiVRMixin extends GuiComponent implements GuiExtension {
 //        return ;
 //    }
 
-    @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/components/PlayerTabOverlay;render(Lcom/mojang/blaze3d/vertex/PoseStack;ILnet/minecraft/world/scores/Scoreboard;Lnet/minecraft/world/scores/Objective;)V"), method = "render")
-    public void noTabList(PlayerTabOverlay instance, PoseStack poseStack, int i, Scoreboard scoreboard, Objective objective) {
-        return ;
+    @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/KeyMapping;isDown()Z"), method = "render")
+    public boolean toggleableTabList(KeyMapping instance) {
+        return instance.isDown() || showPlayerList;
     }
 
     @Inject(at = @At("HEAD"), method = "renderCrosshair", cancellable = true)

--- a/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
@@ -1337,6 +1337,7 @@ public abstract class GameRendererVRMixin
 		if (!GameRendererVRMixin.DATA_HOLDER.bowTracker.isDrawing) {
 			if (this.minecraft.screen != null || !this.minecraft.options.hideGui) {
 				if (!RadialHandler.isShowing()) {
+					minecraft.getProfiler().push("GuiLayer");
 					// cache fog distance
 					float fogStart = RenderSystem.getShaderFogStart();
 
@@ -1452,6 +1453,7 @@ public abstract class GameRendererVRMixin
 
 					poseStack.popPose();
 					RenderSystem.applyModelViewMatrix();
+					minecraft.getProfiler().pop();
 				}
 			}
 		}
@@ -2204,7 +2206,7 @@ public abstract class GameRendererVRMixin
 
 	private void renderCrosshairAtDepth(boolean depthAlways, PoseStack poseStack) {
 		if (this.shouldRenderCrosshair()) {
-			this.minecraft.getProfiler().popPush("crosshair");
+			this.minecraft.getProfiler().push("crosshair");
 			RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
 			Vec3 vec3 = this.crossVec;
 			Vec3 vec31 = vec3.subtract(GameRendererVRMixin.DATA_HOLDER.vrPlayer.vrdata_world_render.getController(0).getPosition());
@@ -2305,6 +2307,7 @@ public abstract class GameRendererVRMixin
 			RenderSystem.enableCull();
 			RenderSystem.depthFunc(515);
 			poseStack.popPose();
+			this.minecraft.getProfiler().pop();
 		}
 	}
 
@@ -2328,6 +2331,7 @@ public abstract class GameRendererVRMixin
 			if (this.minecraft.player.isAlive()) {
 				if (!(((PlayerExtension) this.minecraft.player).getRoomYOffsetFromPose() < 0.0D)) {
 					if (this.minecraft.player.getVehicle() == null) {
+						this.minecraft.getProfiler().push("vr shadow");
 						AABB aabb = this.minecraft.player.getBoundingBox();
 
 						if (GameRendererVRMixin.DATA_HOLDER.vrSettings.vrShowBlueCircleBuddy && aabb != null) {
@@ -2361,6 +2365,7 @@ public abstract class GameRendererVRMixin
 							poseStack.popPose();
 							GlStateManager._enableCull();
 						}
+						this.minecraft.getProfiler().pop();
 					}
 				}
 			}

--- a/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
@@ -447,7 +447,7 @@ public abstract class GameRendererVRMixin
 		return oldVal / 5;
 	}
 
-	@ModifyVariable(at = @At(value = "STORE", ordinal = 1), ordinal = 2, method = "renderLevel", print = true)
+	@ModifyVariable(at = @At(value = "STORE", ordinal = 1), ordinal = 2, method = "renderLevel")
 	public float reduceNauseaAffect(float oldVal) {
 		// scales down the effect from (1,0.65) to (1,0.9)
 		return 1f - (1f - oldVal) * 0.25f;

--- a/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
@@ -2112,6 +2112,7 @@ public abstract class GameRendererVRMixin
 	private void renderFaceInBlock() {
 		Tesselator tesselator = Tesselator.getInstance();
 		BufferBuilder bufferbuilder = tesselator.getBuilder();
+		RenderSystem.setShader(GameRenderer::getPositionShader);
 		RenderSystem.setShaderColor(0.0F, 0.0F, 0.0F, ((GameRendererExtension) this.minecraft.gameRenderer).inBlock());
 
 		// orthographic matrix, (-1, -1) to (1, 1), near = 0.0, far 2.0
@@ -2122,7 +2123,7 @@ public abstract class GameRendererVRMixin
 		mat.m33 = 1.0F;
 		mat.m23 = -1.0F;
 
-		GlStateManager._disableDepthTest();
+		GlStateManager._depthFunc(GL11.GL_ALWAYS);
 		GlStateManager._disableTexture();
 		GlStateManager._enableBlend();
 		GlStateManager._disableCull();
@@ -2132,6 +2133,7 @@ public abstract class GameRendererVRMixin
 		bufferbuilder.vertex(mat, 1.5F, 1.5F, 0.0F).endVertex();
 		bufferbuilder.vertex(mat, -1.5F, 1.5F, 0.0F).endVertex();
 		tesselator.end();
+		GlStateManager._depthFunc(GL11.GL_LEQUAL);
 		GlStateManager._enableTexture();
 		RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
 	}

--- a/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
@@ -1330,6 +1330,9 @@ public abstract class GameRendererVRMixin
 		if (!GameRendererVRMixin.DATA_HOLDER.bowTracker.isDrawing) {
 			if (this.minecraft.screen != null || !this.minecraft.options.hideGui) {
 				if (!RadialHandler.isShowing()) {
+					// cache fog distance
+					float fogStart = RenderSystem.getShaderFogStart();
+
 					boolean flag = this.isInMenuRoom();
 
 					PoseStack poseStack = RenderSystem.getModelViewStack();
@@ -1373,6 +1376,9 @@ public abstract class GameRendererVRMixin
 					if (!flag) {
 						if (this.minecraft.screen == null) {
 							color[3] = GameRendererVRMixin.DATA_HOLDER.vrSettings.hudOpacity;
+						} else {
+							// disable fog for menus
+							RenderSystem.setShaderFogStart(Float.MAX_VALUE);
 						}
 
 						if (this.minecraft.player != null && this.minecraft.player.isShiftKeyDown()) {
@@ -1423,6 +1429,8 @@ public abstract class GameRendererVRMixin
 					}
 
 					// RenderSystem.blendColor(1.0F, 1.0F, 1.0F, 1.0F);
+					// reset fog
+					RenderSystem.setShaderFogStart(fogStart);
 					RenderSystem.depthFunc(515);
 					RenderSystem.enableDepthTest();
 					// RenderSystem.defaultAlphaFunc();

--- a/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
@@ -441,13 +441,16 @@ public abstract class GameRendererVRMixin
 	public void removeBobView(GameRenderer instance, PoseStack poseStack, float f) {
 		return;
 	}
-	
-	public void limiti() {
-		
-	}
-	
-	public void changeVariable() {
 
+	@ModifyVariable(at = @At(value = "STORE"), method = "renderLevel")
+	public int reduceNauseaSpeed(int oldVal) {
+		return oldVal / 5;
+	}
+
+	@ModifyVariable(at = @At(value = "STORE", ordinal = 1), ordinal = 2, method = "renderLevel", print = true)
+	public float reduceNauseaAffect(float oldVal) {
+		// scales down the effect from (1,0.65) to (1,0.9)
+		return 1f - (1f - oldVal) * 0.25f;
 	}
 
 	@Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiling/ProfilerFiller;popPush(Ljava/lang/String;)V", ordinal = 1), method = "renderLevel")

--- a/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
@@ -598,6 +598,8 @@ public abstract class GameRendererVRMixin
 	private void renderVRHands(float partialTicks, boolean renderright, boolean renderleft, boolean menuhandright,
 			boolean menuhandleft, PoseStack poseStack) {
 		this.minecraft.getProfiler().push("hands");
+		// backup projection matrix, not doing that breaks sodium water on 1.19.3
+		RenderSystem.backupProjectionMatrix();
 
 		if (renderright) {
 			this.minecraft.getItemRenderer();
@@ -629,6 +631,7 @@ public abstract class GameRendererVRMixin
 			}
 		}
 
+		RenderSystem.restoreProjectionMatrix();
 		this.minecraft.getProfiler().pop();
 	}
 
@@ -1337,6 +1340,12 @@ public abstract class GameRendererVRMixin
 					// cache fog distance
 					float fogStart = RenderSystem.getShaderFogStart();
 
+					// remove nausea effect from projection matrix, for vanilla, nd posestack for iris
+					this.resetProjectionMatrix(this.getProjectionMatrix(this.getFov(this.mainCamera, par1, true)));
+					pMatrix.pushPose();
+					pMatrix.setIdentity();
+					this.applyVRModelView(GameRendererVRMixin.DATA_HOLDER.currentPass, pMatrix);
+
 					boolean flag = this.isInMenuRoom();
 
 					PoseStack poseStack = RenderSystem.getModelViewStack();
@@ -1369,7 +1378,6 @@ public abstract class GameRendererVRMixin
 						pMatrix.popPose();
 					}
 
-					pMatrix.pushPose();
 					Vec3 vec31 = GuiHandler.applyGUIModelView(GameRendererVRMixin.DATA_HOLDER.currentPass, pMatrix);
 					GuiHandler.guiFramebuffer.bindRead();
 					RenderSystem.disableCull();

--- a/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
@@ -25,6 +25,7 @@ import net.minecraft.client.gui.screens.WinScreen;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.renderer.*;
+import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.ModelBakery;
 import net.minecraft.core.BlockPos;
@@ -1823,13 +1824,13 @@ public abstract class GameRendererVRMixin
 		RenderSystem.setupShaderLights(RenderSystem.getShader());
 
 		bufferbuilder.vertex(pMatrix, (-(size / 2.0F)), (-(size * f) / 2.0F), 0).color(color[0], color[1], color[2], color[3])
-				.uv(0.0F, 0.0F).overlayCoords(0).uv2(light).normal(0.0F, 0.0F, 1.0F).endVertex();
+				.uv(0.0F, 0.0F).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(light).normal(0.0F, 0.0F, 1.0F).endVertex();
 		bufferbuilder.vertex(pMatrix, (size / 2.0F), (-(size * f) / 2.0F), 0).color(color[0], color[1], color[2], color[3])
-				.uv(1.0F, 0.0F).overlayCoords(0).uv2(light).normal(0.0F, 0.0F, 1.0F).endVertex();
+				.uv(1.0F, 0.0F).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(light).normal(0.0F, 0.0F, 1.0F).endVertex();
 		bufferbuilder.vertex(pMatrix, (size / 2.0F), (size * f / 2.0F), 0).color(color[0], color[1], color[2], color[3])
-				.uv(1.0F, 1.0F).overlayCoords(0).uv2(light).normal(0.0F, 0.0F, 1.0F).endVertex();
+				.uv(1.0F, 1.0F).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(light).normal(0.0F, 0.0F, 1.0F).endVertex();
 		bufferbuilder.vertex(pMatrix, (-(size / 2.0F)), (size * f / 2.0F), 0).color(color[0], color[1], color[2], color[3])
-				.uv(0.0F, 1.0F).overlayCoords(0).uv2(light).normal(0.0F, 0.0F, 1.0F).endVertex();
+				.uv(0.0F, 1.0F).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(light).normal(0.0F, 0.0F, 1.0F).endVertex();
 		bufferbuilder.end();
 		BufferUploader.end(bufferbuilder);
 		this.lightTexture.turnOffLightLayer();
@@ -1863,13 +1864,13 @@ public abstract class GameRendererVRMixin
 		RenderSystem.setupShaderLights(RenderSystem.getShader());
 
 		bufferbuilder.vertex(pMatrix, (-(size / 2.0F)), (-(size * f) / 2.0F), 0).color(color[0], color[1], color[2], color[3])
-				.uv(0.0F, 0.0F).overlayCoords(0).uv2(lighti).normal(0,0,1).endVertex();
+				.uv(0.0F, 0.0F).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(lighti).normal(0,0,1).endVertex();
 		bufferbuilder.vertex(pMatrix, (size / 2.0F), (-(size * f) / 2.0F), 0).color(color[0], color[1], color[2], color[3])
-				.uv(1.0F, 0.0F).overlayCoords(0).uv2(lighti).normal(0,0,1).endVertex();
+				.uv(1.0F, 0.0F).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(lighti).normal(0,0,1).endVertex();
 		bufferbuilder.vertex(pMatrix, (size / 2.0F), (size * f / 2.0F), 0).color(color[0], color[1], color[2], color[3])
-				.uv(1.0F, 1.0F).overlayCoords(0).uv2(lighti).normal(0,0,1).endVertex();
+				.uv(1.0F, 1.0F).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(lighti).normal(0,0,1).endVertex();
 		bufferbuilder.vertex(pMatrix, (-(size / 2.0F)), (size * f / 2.0F), 0).color(color[0], color[1], color[2], color[3])
-				.uv(0.0F, 1.0F).overlayCoords(0).uv2(lighti).normal(0,0,1).endVertex();
+				.uv(0.0F, 1.0F).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(lighti).normal(0,0,1).endVertex();
 		bufferbuilder.end();
 		BufferUploader.end(bufferbuilder);
 		this.lightTexture.turnOffLightLayer();

--- a/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/renderer/GameRendererVRMixin.java
@@ -2124,6 +2124,7 @@ public abstract class GameRendererVRMixin
 		mat.m23 = -1.0F;
 
 		GlStateManager._depthFunc(GL11.GL_ALWAYS);
+		GlStateManager._depthMask(true);
 		GlStateManager._disableTexture();
 		GlStateManager._enableBlend();
 		GlStateManager._disableCull();

--- a/common/src/main/java/org/vivecraft/mixin/client/renderer/entity/FishingHookRendererVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/renderer/entity/FishingHookRendererVRMixin.java
@@ -1,7 +1,5 @@
 package org.vivecraft.mixin.client.renderer.entity;
 
-import com.mojang.blaze3d.vertex.PoseStack;
-import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.world.entity.projectile.FishingHook;
@@ -11,7 +9,6 @@ import net.minecraft.client.renderer.entity.FishingHookRenderer;
 import net.minecraft.world.item.FishingRodItem;
 import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.vivecraft.ClientDataHolder;
 import org.vivecraft.extensions.GameRendererExtension;
 
@@ -23,20 +20,14 @@ public abstract class FishingHookRendererVRMixin extends EntityRenderer<FishingH
         super(context);
     }
 
-    private FishingHook currentlyRenderingFishingHook;
     private Vec3 CachedHandPos;
-
-    @Inject(at = @At("HEAD"), method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V")
-    public void storeFishingHook(FishingHook fishingHook, float f, float g, PoseStack poseStack, MultiBufferSource multiBufferSource, int i, CallbackInfo ci){
-        currentlyRenderingFishingHook = fishingHook;
-    }
 
     @ModifyVariable(at = @At(value = "LOAD"),
             method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", index = 25)
-    private double fishingLineStartX(double value) {
-        if ((this.entityRenderDispatcher.options == null || this.entityRenderDispatcher.options.getCameraType().isFirstPerson()) && currentlyRenderingFishingHook.getPlayerOwner() == Minecraft.getInstance().player) {
+    private double fishingLineStartX(double value, FishingHook fishingHook) {
+        if ((this.entityRenderDispatcher.options == null || this.entityRenderDispatcher.options.getCameraType().isFirstPerson()) && fishingHook.getPlayerOwner() == Minecraft.getInstance().player) {
             int j = 1;
-            if (currentlyRenderingFishingHook.getPlayerOwner().getMainHandItem().getItem() instanceof FishingRodItem) {
+            if (fishingHook.getPlayerOwner().getMainHandItem().getItem() instanceof FishingRodItem) {
                 j = 0;
             }
             Vec3 vec31 = ((GameRendererExtension) Minecraft.getInstance().gameRenderer).getControllerRenderPos(j);
@@ -49,8 +40,8 @@ public abstract class FishingHookRendererVRMixin extends EntityRenderer<FishingH
     }
     @ModifyVariable(at = @At(value = "LOAD"),
             method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", index = 27)
-    private double fishingLineStartY(double value) {
-        if ((this.entityRenderDispatcher.options == null || this.entityRenderDispatcher.options.getCameraType().isFirstPerson()) && currentlyRenderingFishingHook.getPlayerOwner() == Minecraft.getInstance().player) {
+    private double fishingLineStartY(double value, FishingHook fishingHook) {
+        if ((this.entityRenderDispatcher.options == null || this.entityRenderDispatcher.options.getCameraType().isFirstPerson()) && fishingHook.getPlayerOwner() == Minecraft.getInstance().player) {
             return CachedHandPos.y;
         } else {
             return value;
@@ -58,8 +49,8 @@ public abstract class FishingHookRendererVRMixin extends EntityRenderer<FishingH
     }
     @ModifyVariable(at = @At(value = "LOAD"),
             method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", index = 29)
-    private double fishingLineStartZ(double value) {
-        if ((this.entityRenderDispatcher.options == null || this.entityRenderDispatcher.options.getCameraType().isFirstPerson()) && currentlyRenderingFishingHook.getPlayerOwner() == Minecraft.getInstance().player) {
+    private double fishingLineStartZ(double value, FishingHook fishingHook) {
+        if ((this.entityRenderDispatcher.options == null || this.entityRenderDispatcher.options.getCameraType().isFirstPerson()) && fishingHook.getPlayerOwner() == Minecraft.getInstance().player) {
             return CachedHandPos.z;
         } else {
             return value;
@@ -67,8 +58,8 @@ public abstract class FishingHookRendererVRMixin extends EntityRenderer<FishingH
     }
     @ModifyVariable(at = @At(value = "LOAD"),
             method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", index = 31)
-    private float fishingLineStartOffset(float value) {
-        if ((this.entityRenderDispatcher.options == null || this.entityRenderDispatcher.options.getCameraType().isFirstPerson()) && currentlyRenderingFishingHook.getPlayerOwner() == Minecraft.getInstance().player) {
+    private float fishingLineStartOffset(float value, FishingHook fishingHook) {
+        if ((this.entityRenderDispatcher.options == null || this.entityRenderDispatcher.options.getCameraType().isFirstPerson()) && fishingHook.getPlayerOwner() == Minecraft.getInstance().player) {
             return 0.0F;
         } else {
             return value;

--- a/common/src/main/java/org/vivecraft/mixin/client/renderer/entity/FishingHookRendererVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/renderer/entity/FishingHookRendererVRMixin.java
@@ -2,6 +2,8 @@ package org.vivecraft.mixin.client.renderer.entity;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.EntityRenderer;
+import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.world.entity.projectile.FishingHook;
 import org.spongepowered.asm.mixin.injection.*;
 import net.minecraft.client.Minecraft;
@@ -14,7 +16,12 @@ import org.vivecraft.ClientDataHolder;
 import org.vivecraft.extensions.GameRendererExtension;
 
 @Mixin(FishingHookRenderer.class)
-public class FishingHookRendererVRMixin {
+public abstract class FishingHookRendererVRMixin extends EntityRenderer<FishingHook> {
+
+    // dummy constructor
+    protected FishingHookRendererVRMixin(EntityRendererProvider.Context context) {
+        super(context);
+    }
 
     private FishingHook currentlyRenderingFishingHook;
     private Vec3 CachedHandPos;
@@ -24,32 +31,47 @@ public class FishingHookRendererVRMixin {
         currentlyRenderingFishingHook = fishingHook;
     }
 
-    @ModifyVariable(at = @At(value = "STORE", ordinal = 1),
+    @ModifyVariable(at = @At(value = "LOAD"),
             method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", index = 25)
     private double fishingLineStartX(double value) {
-        int j = 1;
-        if (currentlyRenderingFishingHook.getPlayerOwner().getMainHandItem().getItem() instanceof FishingRodItem)
-        {
-            j = 0;
+        if ((this.entityRenderDispatcher.options == null || this.entityRenderDispatcher.options.getCameraType().isFirstPerson()) && currentlyRenderingFishingHook.getPlayerOwner() == Minecraft.getInstance().player) {
+            int j = 1;
+            if (currentlyRenderingFishingHook.getPlayerOwner().getMainHandItem().getItem() instanceof FishingRodItem) {
+                j = 0;
+            }
+            Vec3 vec31 = ((GameRendererExtension) Minecraft.getInstance().gameRenderer).getControllerRenderPos(j);
+            Vec3 vec32 = ClientDataHolder.getInstance().vrPlayer.vrdata_world_render.getHand(j).getDirection();
+            CachedHandPos = vec31.add(vec32.scale(0.47 * ClientDataHolder.getInstance().vrPlayer.vrdata_world_render.worldScale));
+            return CachedHandPos.x;
+        } else {
+            return value;
         }
-        Vec3 vec31 = ((GameRendererExtension) Minecraft.getInstance().gameRenderer).getControllerRenderPos(j);
-        Vec3 vec32 = ClientDataHolder.getInstance().vrPlayer.vrdata_world_render.getHand(j).getDirection();
-        CachedHandPos = vec31.add(vec32.scale(0.47 * ClientDataHolder.getInstance().vrPlayer.vrdata_world_render.worldScale));
-        return CachedHandPos.x;
     }
-    @ModifyVariable(at = @At(value = "STORE", ordinal = 1),
+    @ModifyVariable(at = @At(value = "LOAD"),
             method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", index = 27)
     private double fishingLineStartY(double value) {
-        return CachedHandPos.y;
+        if ((this.entityRenderDispatcher.options == null || this.entityRenderDispatcher.options.getCameraType().isFirstPerson()) && currentlyRenderingFishingHook.getPlayerOwner() == Minecraft.getInstance().player) {
+            return CachedHandPos.y;
+        } else {
+            return value;
+        }
     }
-    @ModifyVariable(at = @At(value = "STORE", ordinal = 1),
+    @ModifyVariable(at = @At(value = "LOAD"),
             method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", index = 29)
     private double fishingLineStartZ(double value) {
-        return CachedHandPos.z;
+        if ((this.entityRenderDispatcher.options == null || this.entityRenderDispatcher.options.getCameraType().isFirstPerson()) && currentlyRenderingFishingHook.getPlayerOwner() == Minecraft.getInstance().player) {
+            return CachedHandPos.z;
+        } else {
+            return value;
+        }
     }
-    @ModifyVariable(at = @At(value = "STORE", ordinal = 1),
+    @ModifyVariable(at = @At(value = "LOAD"),
             method = "render(Lnet/minecraft/world/entity/projectile/FishingHook;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", index = 31)
     private float fishingLineStartOffset(float value) {
-        return 0.0F;
+        if ((this.entityRenderDispatcher.options == null || this.entityRenderDispatcher.options.getCameraType().isFirstPerson()) && currentlyRenderingFishingHook.getPlayerOwner() == Minecraft.getInstance().player) {
+            return 0.0F;
+        } else {
+            return value;
+        }
     }
 }

--- a/common/src/main/java/org/vivecraft/mixin/world/entity/projectile/FishingHookMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/world/entity/projectile/FishingHookMixin.java
@@ -2,11 +2,10 @@ package org.vivecraft.mixin.world.entity.projectile;
 
 import net.minecraft.world.entity.Entity;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
-import org.vivecraft.api.ClientNetworkHelper;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.vivecraft.api.CommonNetworkHelper;
 import org.vivecraft.api.ServerVivePlayer;
 
@@ -19,25 +18,47 @@ import net.minecraft.world.phys.Vec3;
 
 @Mixin(FishingHook.class)
 public abstract class FishingHookMixin extends Entity {
-	
+
 	protected FishingHookMixin(EntityType<? extends Projectile> p_37248_, Level p_37249_) {
 		super(p_37248_, p_37249_);
 		// TODO Auto-generated constructor stub
 	}
 
-	@Inject(at = @At(value = "RETURN", target = "Lnet/minecraft/world/entity/player/Player;getYRot()F"), 
-			method = "<init>(Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/level/Level;II)V", 
-			locals = LocalCapture.CAPTURE_FAILHARD)
-	public void hook(Player p_37106_, Level p_37107_, int p_37108_, int p_37109_ , CallbackInfo info, float f, float f1) {
-		ServerVivePlayer serverviveplayer = CommonNetworkHelper.vivePlayers.get(p_37106_.getUUID());
+	@Unique
+	private ServerVivePlayer serverviveplayer = null;
+	@Unique
+	private Vec3 controllerDir = null;
+	@Unique
+	private Vec3 controllerPos = null;
+
+	@ModifyVariable(at = @At(value = "STORE"), method = "<init>(Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/level/Level;II)V", ordinal = 0)
+	private float modifyXrot(float xRot, Player player) {
+		serverviveplayer = CommonNetworkHelper.vivePlayers.get(player.getUUID());
 		if (serverviveplayer != null && serverviveplayer.isVR()) {
-			Vec3 vec32 = serverviveplayer.getControllerDir(serverviveplayer.activeHand);
-			Vec3 vec3 = serverviveplayer.getControllerPos(serverviveplayer.activeHand, p_37106_);
-			f = -((float) Math.toDegrees(Math.asin(vec32.y / vec32.length())));
-			f1 = (float) Math.toDegrees(Math.atan2(-vec32.x, vec32.z));
-			this.moveTo(vec3.x + vec32.x * (double)0.6F, vec3.y + vec32.y * (double)0.6F, vec3.z + vec32.z * (double)0.6F, f1, f);
+			controllerDir = serverviveplayer.getControllerDir(serverviveplayer.activeHand);
+			controllerPos = serverviveplayer.getControllerPos(serverviveplayer.activeHand, player);
+			return -((float) Math.toDegrees(Math.asin(controllerDir.y / controllerDir.length())));
 		}
-		
+		return xRot;
+	}
+	@ModifyVariable(at = @At(value = "STORE"), method = "<init>(Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/level/Level;II)V", ordinal = 1)
+	private float modifyYrot(float yRot) {
+		if (serverviveplayer != null && serverviveplayer.isVR()) {
+			return (float) Math.toDegrees(Math.atan2(-controllerDir.x, controllerDir.z));
+		}
+		return yRot;
 	}
 
+	@Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/projectile/FishingHook;moveTo(DDDFF)V"), method = "<init>(Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/level/Level;II)V")
+	private void modifyMoveTo(FishingHook instance, double x, double y, double z, float yRot, float xRot) {
+		if (serverviveplayer != null && serverviveplayer.isVR()) {
+			instance.moveTo(controllerPos.x + controllerDir.x * (double)0.6F, controllerPos.y + controllerDir.y * (double)0.6F, controllerPos.z + controllerDir.z * (double)0.6F, yRot, xRot);
+			controllerDir = null;
+			controllerPos = null;
+		} else {
+			this.moveTo(x, y, z, yRot, xRot);
+		}
+
+		serverviveplayer = null;
+	}
 }

--- a/common/src/main/java/org/vivecraft/mixin/world/entity/projectile/FishingHookVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/world/entity/projectile/FishingHookVRMixin.java
@@ -1,0 +1,56 @@
+package org.vivecraft.mixin.world.entity.projectile;
+
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.projectile.FishingHook;
+import net.minecraft.world.item.FishingRodItem;
+import net.minecraft.world.level.Level;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.vivecraft.provider.ControllerType;
+import org.vivecraft.provider.MCVR;
+
+@Mixin(FishingHook.class)
+public abstract class FishingHookVRMixin extends Entity {
+
+    @Shadow private boolean biting;
+
+    @Shadow
+    public abstract Player getPlayerOwner();
+
+    public FishingHookVRMixin(EntityType<?> entityType, Level level) {
+        super(entityType, level);
+    }
+
+    @Unique
+    private boolean wasBiting = false;
+    @Unique
+    private boolean wasNibble = false;
+
+    @Inject(at = @At(value = "HEAD"), method = "tick")
+    private void fishhookFeedback(CallbackInfo ci){
+        Player player = this.getPlayerOwner();
+        if (player != null && player.isLocalPlayer())
+        {
+            if (biting && !wasBiting) {
+                // bite, big feedback
+                MCVR.get().triggerHapticPulse(
+                        player.getMainHandItem().getItem() instanceof FishingRodItem ? ControllerType.RIGHT : ControllerType.LEFT,
+                        0.001F, 160.0F, 1.0F);
+            } else if (getDeltaMovement().y < -0.01 && !wasNibble) {
+                // nibble, small feedback
+                MCVR.get().triggerHapticPulse(
+                        player.getMainHandItem().getItem() instanceof FishingRodItem ? ControllerType.RIGHT : ControllerType.LEFT,
+                        0.000001F, 160.0F, 1.0F);
+                wasNibble = true;
+            }
+        }
+        wasBiting = biting;
+        wasNibble = wasNibble && getDeltaMovement().y < 0.0;
+    }
+}

--- a/common/src/main/java/org/vivecraft/provider/MCVR.java
+++ b/common/src/main/java/org/vivecraft/provider/MCVR.java
@@ -783,6 +783,16 @@ public abstract class MCVR
                 this.controllerRotation[0].M[2][0] = matrix4f.m20;
                 this.controllerRotation[0].M[2][1] = matrix4f.m21;
                 this.controllerRotation[0].M[2][2] = matrix4f.m22;
+
+                this.handRotation[0].M[0][0] = matrix4f.m00;
+                this.handRotation[0].M[0][1] = matrix4f.m01;
+                this.handRotation[0].M[0][2] = matrix4f.m02;
+                this.handRotation[0].M[1][0] = matrix4f.m10;
+                this.handRotation[0].M[1][1] = matrix4f.m11;
+                this.handRotation[0].M[1][2] = matrix4f.m12;
+                this.handRotation[0].M[2][0] = matrix4f.m20;
+                this.handRotation[0].M[2][1] = matrix4f.m21;
+                this.handRotation[0].M[2][2] = matrix4f.m22;
             }
 
             Vec3 vec32 = this.getAimVector(0);

--- a/common/src/main/java/org/vivecraft/render/VRShaders.java
+++ b/common/src/main/java/org/vivecraft/render/VRShaders.java
@@ -39,11 +39,6 @@ public class VRShaders
     public static AbstractUniform _Overlay_time;
     public static AbstractUniform _Overlay_BlackAlpha;
     public static AbstractUniform _Overlay_eye;
-    public static final String PASSTHRU_VERTEX_SHADER = Utils.loadAssetAsString("shaders/passthru.vsh", true);
-    public static final String DEPTH_MASK_FRAGMENT_SHADER = Utils.loadAssetAsString("shaders/mixedreality.fsh", true);
-    public static final String LANCZOS_SAMPLER_VERTEX_SHADER = Utils.loadAssetAsString("shaders/lanczos.vsh", true);
-    public static final String LANCZOS_SAMPLER_FRAGMENT_SHADER = Utils.loadAssetAsString("shaders/lanczos.fsh", true);
-    public static final String FOV_REDUCTION_FRAGMENT_SHADER = Utils.loadAssetAsString("shaders/fovreduction.fsh", true);
 
     private VRShaders()
     {

--- a/common/src/main/java/org/vivecraft/settings/profile/ProfileManager.java
+++ b/common/src/main/java/org/vivecraft/settings/profile/ProfileManager.java
@@ -15,10 +15,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.google.gson.JsonPrimitive;
+import com.google.gson.*;
 
 
 public class ProfileManager
@@ -34,6 +31,7 @@ public class ProfileManager
     static File vrProfileCfgFile = null;
     static JsonObject jsonConfigRoot = null;
     static JsonObject profiles = null;
+    static final Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
     static boolean loaded = false;
     public static final String[] DEFAULT_BINDINGS = new String[] {"key.playerlist:b:6:Button 6", "axis.updown:a:2:-:Y Rotation", "walk.forward:a:0:-:Y ", "gui.axis.leftright:a:3:-:X Rotation", "gui.axis.updown:a:2:-:Y Rotation", "key.sneak:b:9:Button 9", "gui.Left:px:-", "key.itemright:b:5:Button 5", "gui.Right:px:+", "key.left:a:1:-:X ", "gui.Select:b:0:Button 0", "key.aimcenter:b:8:Button 8", "key.pickItem:b:2:Button 2", "key.menu:b:7:Button 7", "key.attack:a:4:-:Z ", "gui.Up:py:-", "key.use:a:4:+:Z ", "axis.leftright:a:3:-:X Rotation", "gui.Down:py:+", "key.right:a:1:+:X ", "key.back:a:0:+:Y ", "key.inventory:b:3:Button 3", "key.jump:b:0:Button 0", "key.drop:b:1:Button 1", "gui.Back:b:1:Button 1", "key.itemleft:b:4:Button 4"};
 
@@ -319,7 +317,7 @@ public class ProfileManager
         try
         {
             OutputStreamWriter outputstreamwriter = new OutputStreamWriter(new FileOutputStream(vrProfileCfgFile), "UTF-8");
-            String s = jsonConfigRoot.toString();
+            String s = gson.toJson(jsonConfigRoot);
             outputstreamwriter.write(s);
             outputstreamwriter.flush();
             outputstreamwriter.close();

--- a/common/src/main/resources/vivecraft.vr.mixins.json
+++ b/common/src/main/resources/vivecraft.vr.mixins.json
@@ -48,6 +48,7 @@
     "client.renderer.PostChainVRMixin",
 
     "world.entity.vehicle.BoatMixin",
+    "world.entity.projectile.FishingHookVRMixin",
     "world.item.ItemVRMixin",
     "world.item.PotionItemVRMixin"
   ],

--- a/common/src/main/resources/vivecraft.vr.mixins.json
+++ b/common/src/main/resources/vivecraft.vr.mixins.json
@@ -14,6 +14,7 @@
     "blaze3d.platform.GlStateManagerVRMixin",
     "blaze3d.systems.RenderSystemVRMixin",
     "blaze3d.systems.RenderSystemAccessor",
+    "client.ClientBrandRetrieverVRMixin",
     "client.KeyboardHandlerVRMixin",
     "client.MinecraftVRMixin",
     "client.MouseHandlerVRMixin",

--- a/forge/src/main/java/org/vivecraft/forge/mixin/ForgeIngameGuiVRMixin.java
+++ b/forge/src/main/java/org/vivecraft/forge/mixin/ForgeIngameGuiVRMixin.java
@@ -21,7 +21,7 @@ public abstract class ForgeIngameGuiVRMixin{
         }
     }
 
-    @Redirect(method = "Lnet/minecraftforge/client/gui/ForgeIngameGui;renderPlayerList(IILcom/mojang/blaze3d/vertex/PoseStack;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/KeyMapping;isDown()Z"))
+    @Redirect(method = "renderPlayerList(IILcom/mojang/blaze3d/vertex/PoseStack;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/KeyMapping;isDown()Z"))
     public boolean toggleableTabListForge(KeyMapping instance) {
         return instance.isDown() || ((GuiExtension)this).getShowPlayerList();
     }

--- a/forge/src/main/java/org/vivecraft/forge/mixin/ForgeIngameGuiVRMixin.java
+++ b/forge/src/main/java/org/vivecraft/forge/mixin/ForgeIngameGuiVRMixin.java
@@ -1,20 +1,28 @@
 package org.vivecraft.forge.mixin;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.KeyMapping;
 import net.minecraftforge.client.gui.ForgeIngameGui;
 import net.minecraftforge.client.gui.IIngameOverlay;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.vivecraft.extensions.GuiExtension;
 
 @Mixin(ForgeIngameGui.class)
-public abstract class ForgeIngameGuiVRMixin {
+public abstract class ForgeIngameGuiVRMixin{
 
     @Inject(method = "pre(Lnet/minecraftforge/client/gui/IIngameOverlay;Lcom/mojang/blaze3d/vertex/PoseStack;)Z", at = @At("HEAD"), remap = false, cancellable = true)
     private void noStuff(IIngameOverlay overlay, PoseStack poseStack, CallbackInfoReturnable<Boolean> info) {
         if (overlay == ForgeIngameGui.VIGNETTE_ELEMENT || overlay == ForgeIngameGui.SPYGLASS_ELEMENT || overlay == ForgeIngameGui.HELMET_ELEMENT || overlay == ForgeIngameGui.FROSTBITE_ELEMENT || overlay == ForgeIngameGui.PORTAL_ELEMENT) {
             info.setReturnValue(true);
         }
+    }
+
+    @Redirect(method = "Lnet/minecraftforge/client/gui/ForgeIngameGui;renderPlayerList(IILcom/mojang/blaze3d/vertex/PoseStack;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/KeyMapping;isDown()Z"))
+    public boolean toggleableTabListForge(KeyMapping instance) {
+        return instance.isDown() || ((GuiExtension)this).getShowPlayerList();
     }
 }


### PR DESCRIPTION
fix error screen rendering with iris shaders on
fix black screen in block overlay with shaders/journexmap, and the menu hands rendering
change client brand to 'vivecraft' in VR
enables pretty printing of the config
removes unnecessary shader loading, which sometimes cause crashes.
fix fishing line on forge 1.19+