### PR TITLE
No more vivecraft title

### DIFF
--- a/common/src/main/java/org/vivecraft/CommonDataHolder.java
+++ b/common/src/main/java/org/vivecraft/CommonDataHolder.java
@@ -16,9 +16,9 @@ public class CommonDataHolder {
         }
 
         if (VRState.checkVR()) {
-            minecriftVerString = "Vivecraft " + mcVersion + " jrbudda-VR-" + Xplat.getModloader() + "-" + modVersion;
+            minecriftVerString = "Vivecraft " + mcVersion + " VR-" + Xplat.getModloader() + "-" + modVersion;
         } else {
-            minecriftVerString = "Vivecraft " + mcVersion + " jrbudda-NONVR-" + Xplat.getModloader() + "-" + modVersion;
+            minecriftVerString = "Vivecraft " + mcVersion + " NONVR-" + Xplat.getModloader() + "-" + modVersion;
         }
     }
 

--- a/common/src/main/java/org/vivecraft/mixin/client/MinecraftMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/MinecraftMixin.java
@@ -1,16 +1,15 @@
 package org.vivecraft.mixin.client;
 
-import org.vivecraft.ClientDataHolder;
 import net.minecraft.client.Minecraft;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.At.Shift;
-import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.vivecraft.CommonDataHolder;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import org.vivecraft.VRState;
 import org.vivecraft.render.PlayerModelController;
 
 @Mixin(Minecraft.class)
@@ -20,9 +19,11 @@ public abstract class MinecraftMixin {
     @Shadow
     protected abstract int getFramerateLimit();
 
-    @ModifyConstant(method = "createTitle", constant = @Constant(stringValue = "Minecraft"))
-    private String title(String s) {
-        return CommonDataHolder.getInstance().minecriftVerString;
+    @Inject(method = "createTitle", at = @At(value = "INVOKE", target = "Ljava/lang/StringBuilder;toString()Ljava/lang/String;", shift = Shift.BEFORE),  locals = LocalCapture.CAPTURE_FAILHARD)
+    private void title(CallbackInfoReturnable<String> cir, StringBuilder stringBuilder) {
+        if (VRState.isVR) {
+            stringBuilder.append(" (VR)");
+        }
     }
 
     @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/sounds/SoundManager;tick(Z)V", shift = Shift.BEFORE), method = "tick()V", cancellable = true)


### PR DESCRIPTION
simplifies the window title, to show a `(VR)` when vr is on, and nothing for nonvr
also removes the `jrbudda` from the network version string