### PR TITLE
Enable in-game keyboard to optionally activate key bindings

### DIFF
--- a/common/src/main/java/org/vivecraft/client/gui/settings/GuiHUDSettings.java
+++ b/common/src/main/java/org/vivecraft/client/gui/settings/GuiHUDSettings.java
@@ -33,6 +33,7 @@ public class GuiHUDSettings extends GuiVROptionsBase {
             return true;
         }),
         new VROptionEntry(VRSettings.VrOptions.PHYSICAL_KEYBOARD_THEME),
+        new VROptionEntry(VRSettings.VrOptions.KEYBOARD_PRESS_BINDS),
         new VROptionEntry(VRSettings.VrOptions.SHADER_GUI_RENDER)
     };
 

--- a/common/src/main/java/org/vivecraft/client_vr/gameplay/screenhandlers/KeyboardHandler.java
+++ b/common/src/main/java/org/vivecraft/client_vr/gameplay/screenhandlers/KeyboardHandler.java
@@ -56,6 +56,9 @@ public class KeyboardHandler {
                 }
             } else {
                 Showing = false;
+                if (dh.vrSettings.physicalKeyboard) {
+                    physicalKeyboard.unpressAllKeys();
+                }
             }
 
             return Showing;

--- a/common/src/main/java/org/vivecraft/client_vr/gui/GuiKeyboard.java
+++ b/common/src/main/java/org/vivecraft/client_vr/gui/GuiKeyboard.java
@@ -5,10 +5,12 @@ import net.minecraft.client.gui.components.Button;
 import net.minecraft.network.chat.Component;
 import org.lwjgl.glfw.GLFW;
 import org.vivecraft.client.gui.framework.TwoHandedScreen;
+import org.vivecraft.client.utils.Utils;
 import org.vivecraft.client_vr.provider.InputSimulator;
 
 public class GuiKeyboard extends TwoHandedScreen {
     private boolean isShift = false;
+    private long airTypingWarningTime;
 
     public void init() {
         String s = this.dataholder.vrSettings.keyboardKeys;
@@ -42,8 +44,11 @@ public class GuiKeyboard extends TwoHandedScreen {
                 }
 
                 String s2 = String.valueOf(c0);
+                final int code = l1 < this.dataholder.vrSettings.keyboardCodes.length ? this.dataholder.vrSettings.keyboardCodes[l1] : GLFW.GLFW_KEY_UNKNOWN;
                 Button button = new Button.Builder(Component.literal(s2), (p) ->
                 {
+                    InputSimulator.pressKeyForBind(code);
+                    InputSimulator.releaseKeyForBind(code);
                     InputSimulator.typeChars(s2);
                 })
                     .size(i1, 20)
@@ -62,6 +67,8 @@ public class GuiKeyboard extends TwoHandedScreen {
             .build());
         this.addRenderableWidget(new Button.Builder(Component.literal(" "), (p) ->
         {
+            InputSimulator.pressKeyForBind(GLFW.GLFW_KEY_SPACE);
+            InputSimulator.releaseKeyForBind(GLFW.GLFW_KEY_SPACE);
             InputSimulator.typeChars(" ");
         })
             .size(5 * (i1 + l), 20)

--- a/common/src/main/java/org/vivecraft/client_vr/gui/PhysicalKeyboard.java
+++ b/common/src/main/java/org/vivecraft/client_vr/gui/PhysicalKeyboard.java
@@ -12,6 +12,7 @@ import net.minecraft.client.gui.Font;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.resources.sounds.SimpleSoundInstance;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.util.Mth;
@@ -90,6 +91,7 @@ public class PhysicalKeyboard {
     }
 
     public void init() {
+        this.unpressAllKeys();
         this.keys.clear();
         this.rows = ROWS;
         this.columns = COLUMNS;
@@ -118,9 +120,11 @@ public class PhysicalKeyboard {
                 }
 
                 final char c1 = c0;
+                final int code = k < this.dh.vrSettings.keyboardCodes.length ? this.dh.vrSettings.keyboardCodes[k] : GLFW.GLFW_KEY_UNKNOWN;
                 this.addKey(new KeyButton(k, String.valueOf(c0), this.keyWidthSpecial + this.spacing + (float) j * (this.keyWidth + this.spacing), (float) i * (this.keyHeight + this.spacing), this.keyWidth, this.keyHeight) {
                     @Override
                     public void onPressed() {
+                        InputSimulator.pressKeyForBind(code);
                         InputSimulator.typeChar(c1);
 
                         if (!PhysicalKeyboard.this.shiftSticky) {
@@ -131,6 +135,11 @@ public class PhysicalKeyboard {
                             InputSimulator.pressKey(GLFW.GLFW_KEY_SLASH);
                             InputSimulator.releaseKey(GLFW.GLFW_KEY_SLASH);
                         }
+                    }
+
+                    @Override
+                    public void onReleased() {
+                        InputSimulator.releaseKeyForBind(code);
                     }
                 });
             }
@@ -169,13 +178,23 @@ public class PhysicalKeyboard {
         this.addKey(new KeyButton(1002, " ", this.keyWidthSpecial + this.spacing + (float) (this.columns - 5) / 2.0F * (this.keyWidth + this.spacing), (float) this.rows * (this.keyHeight + this.spacing), 5.0F * (this.keyWidth + this.spacing) - this.spacing, this.keyHeight) {
             @Override
             public void onPressed() {
+                InputSimulator.pressKeyForBind(GLFW.GLFW_KEY_SPACE);
                 InputSimulator.typeChar(' ');
+            }
+
+            @Override
+            public void onReleased() {
+                InputSimulator.releaseKeyForBind(GLFW.GLFW_KEY_SPACE);
             }
         });
         this.addKey(new KeyButton(1003, "Tab", 0.0F, this.keyHeight + this.spacing, this.keyWidthSpecial, this.keyHeight) {
             @Override
             public void onPressed() {
                 InputSimulator.pressKey(GLFW.GLFW_KEY_TAB);
+            }
+
+            @Override
+            public void onReleased() {
                 InputSimulator.releaseKey(GLFW.GLFW_KEY_TAB);
             }
         });
@@ -183,6 +202,10 @@ public class PhysicalKeyboard {
             @Override
             public void onPressed() {
                 InputSimulator.pressKey(GLFW.GLFW_KEY_ESCAPE);
+            }
+
+            @Override
+            public void onReleased() {
                 InputSimulator.releaseKey(GLFW.GLFW_KEY_ESCAPE);
             }
         });
@@ -190,6 +213,10 @@ public class PhysicalKeyboard {
             @Override
             public void onPressed() {
                 InputSimulator.pressKey(GLFW.GLFW_KEY_BACKSPACE);
+            }
+
+            @Override
+            public void onReleased() {
                 InputSimulator.releaseKey(GLFW.GLFW_KEY_BACKSPACE);
             }
         });
@@ -197,6 +224,10 @@ public class PhysicalKeyboard {
             @Override
             public void onPressed() {
                 InputSimulator.pressKey(GLFW.GLFW_KEY_ENTER);
+            }
+
+            @Override
+            public void onReleased() {
                 InputSimulator.releaseKey(GLFW.GLFW_KEY_ENTER);
             }
         });
@@ -204,6 +235,10 @@ public class PhysicalKeyboard {
             @Override
             public void onPressed() {
                 InputSimulator.pressKey(GLFW.GLFW_KEY_UP);
+            }
+
+            @Override
+            public void onReleased() {
                 InputSimulator.releaseKey(GLFW.GLFW_KEY_UP);
             }
         });
@@ -211,6 +246,10 @@ public class PhysicalKeyboard {
             @Override
             public void onPressed() {
                 InputSimulator.pressKey(GLFW.GLFW_KEY_DOWN);
+            }
+
+            @Override
+            public void onReleased() {
                 InputSimulator.releaseKey(GLFW.GLFW_KEY_DOWN);
             }
         });
@@ -218,6 +257,10 @@ public class PhysicalKeyboard {
             @Override
             public void onPressed() {
                 InputSimulator.pressKey(GLFW.GLFW_KEY_LEFT);
+            }
+
+            @Override
+            public void onReleased() {
                 InputSimulator.releaseKey(GLFW.GLFW_KEY_LEFT);
             }
         });
@@ -225,6 +268,10 @@ public class PhysicalKeyboard {
             @Override
             public void onPressed() {
                 InputSimulator.pressKey(GLFW.GLFW_KEY_RIGHT);
+            }
+
+            @Override
+            public void onReleased() {
                 InputSimulator.releaseKey(GLFW.GLFW_KEY_RIGHT);
             }
         });
@@ -332,7 +379,7 @@ public class PhysicalKeyboard {
             if (physicalkeyboard$keybutton != null) {
                 if (physicalkeyboard$keybutton != this.pressedKey[i] && Utils.milliTime() - this.pressTime[i] >= 150L) {
                     if (this.pressedKey[i] != null) {
-                        this.pressedKey[i].unpress(controllertype);
+                        this.pressedKey[i].unpress();
                         this.pressedKey[i] = null;
                     }
 
@@ -345,7 +392,7 @@ public class PhysicalKeyboard {
                     this.pressRepeatTime[i] = Utils.milliTime();
                 }
             } else if (this.pressedKey[i] != null) {
-                this.pressedKey[i].unpress(controllertype);
+                this.pressedKey[i].unpress();
                 this.pressedKey[i] = null;
                 this.pressTime[i] = Utils.milliTime();
             }
@@ -535,6 +582,12 @@ public class PhysicalKeyboard {
         this.reinit = true;
     }
 
+    public void unpressAllKeys() {
+        for (KeyButton key : this.keys) {
+            if(key.pressed) key.unpress();
+        }
+    }
+
     private KeyButton addKey(KeyButton key) {
         this.keys.add(key);
         return key;
@@ -609,11 +662,13 @@ public class PhysicalKeyboard {
             PhysicalKeyboard.this.updateEasterEgg(this.label);
         }
 
-        public final void unpress(ControllerType controller) {
+        public final void unpress() {
             this.pressed = false;
+            this.onReleased();
         }
 
         public abstract void onPressed();
+        public void onReleased() {}
     }
 
     public enum KeyboardTheme implements OptionEnum<KeyboardTheme> {

--- a/common/src/main/java/org/vivecraft/client_vr/provider/InputSimulator.java
+++ b/common/src/main/java/org/vivecraft/client_vr/provider/InputSimulator.java
@@ -1,9 +1,14 @@
 package org.vivecraft.client_vr.provider;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.Component;
+import org.lwjgl.glfw.GLFW;
 
 import java.util.HashSet;
 import java.util.Set;
+
+import org.vivecraft.client.utils.Utils;
+import org.vivecraft.client_vr.ClientDataHolderVR;
 
 public class InputSimulator {
     private static final Set<Integer> pressedKeys = new HashSet<>();
@@ -68,6 +73,30 @@ public class InputSimulator {
         for (int j = 0; j < i; ++j) {
             char c0 = characters.charAt(j);
             typeChar(c0);
+        }
+    }
+
+    private static long airTypingWarningTime;
+    public static void pressKeyForBind(int code) {
+        Minecraft minecraft = Minecraft.getInstance();
+        ClientDataHolderVR dataHolder = ClientDataHolderVR.getInstance();
+
+        if (dataHolder.vrSettings.keyboardPressBinds) {
+            if (code != GLFW.GLFW_KEY_UNKNOWN) {
+                pressKey(code);
+            }
+        } else if (minecraft.screen == null && Utils.milliTime() - airTypingWarningTime >= 30000) {
+            minecraft.gui.getChat().addMessage(Component.translatable("vivecraft.messages.airtypingwarning"));
+            airTypingWarningTime = Utils.milliTime();
+        }
+    }
+
+
+    public static void releaseKeyForBind(int code) {
+        ClientDataHolderVR dataHolder = ClientDataHolderVR.getInstance();
+
+        if (dataHolder.vrSettings.keyboardPressBinds && code != GLFW.GLFW_KEY_UNKNOWN) {
+            releaseKey(code);
         }
     }
 }

--- a/common/src/main/java/org/vivecraft/client_vr/settings/SettingField.java
+++ b/common/src/main/java/org/vivecraft/client_vr/settings/SettingField.java
@@ -31,4 +31,13 @@ public @interface SettingField {
      * @return whether to separate keys
      */
     boolean separate() default false;
+
+    /**
+     * If true, arrays will always be kept the same size when loading. If false,
+     * the size of the array can vary. If {@link #separate} is true, setting this
+     * to false will have no effect and the array will always be the same size.
+     *
+     * @return whether to separate keys
+     */
+    boolean fixedSize() default true;
 }

--- a/common/src/main/java/org/vivecraft/client_vr/settings/VRSettings.java
+++ b/common/src/main/java/org/vivecraft/client_vr/settings/VRSettings.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.lwjgl.glfw.GLFW;
 import org.vivecraft.client.utils.LangHelper;
 import org.vivecraft.client_vr.ClientDataHolderVR;
 import org.vivecraft.client_vr.VRState;
@@ -171,6 +172,8 @@ public class VRSettings {
     public String[] vrRadialItems = getRadialItemsDefault();
     @SettingField(config = "RADIALALT", separate = true)
     public String[] vrRadialItemsAlt = getRadialItemsAltDefault();
+    @SettingField(fixedSize = false)
+    public int[] keyboardCodes = getKeyboardCodesDefault();
 
     //Control
     @SettingField(VrOptions.REVERSE_HANDS)
@@ -402,6 +405,8 @@ public class VRSettings {
     public float physicalKeyboardScale = 1.0f;
     @SettingField(VrOptions.PHYSICAL_KEYBOARD_THEME)
     public PhysicalKeyboard.KeyboardTheme physicalKeyboardTheme = PhysicalKeyboard.KeyboardTheme.DEFAULT;
+    @SettingField(VrOptions.KEYBOARD_PRESS_BINDS)
+    public boolean keyboardPressBinds = false;
     @SettingField(VrOptions.ALLOW_ADVANCED_BINDINGS)
     public boolean allowAdvancedBindings = false;
     @SettingField(VrOptions.CHAT_NOTIFICATIONS)
@@ -451,8 +456,8 @@ public class VRSettings {
 
     public ServerOverrides overrides = new ServerOverrides();
 
-    private final Map<VrOptions, Triple<Field, String, Boolean>> fieldEnumMap = new EnumMap<>(VrOptions.class);
-    private final Map<String, Triple<Field, VrOptions, Boolean>> fieldConfigMap = new HashMap<>();
+    private final Map<VrOptions, ConfigEntry> fieldEnumMap = new EnumMap<>(VrOptions.class);
+    private final Map<String, ConfigEntry> fieldConfigMap = new HashMap<>();
 
     // This map is only here to preserve old settings, not intended for general use
     private Map<String, String> preservedSettingMap;
@@ -489,14 +494,14 @@ public class VRSettings {
                 }
 
                 String config = ann.config().isEmpty() ? field.getName() : ann.config();
+                ConfigEntry configEntry = new ConfigEntry(field, ann.value(), config, ann.separate(), ann.fixedSize());
                 if (ann.value() != VrOptions.DUMMY) {
                     if (fieldEnumMap.containsKey(ann.value())) {
                         throw new RuntimeException("duplicate enum in setting field: " + field.getName());
                     }
-                    fieldEnumMap.put(ann.value(), Triple.of(field, config, ann.separate()));
+                    fieldEnumMap.put(ann.value(), configEntry);
                 }
 
-                Triple<Field, VrOptions, Boolean> configEntry = Triple.of(field, ann.value(), ann.separate());
                 if (ann.separate() && field.getType().isArray()) {
                     int len = Array.getLength(field.get(this));
                     IntStream.range(0, len).forEach(i -> fieldConfigMap.put(config + "_" + i, configEntry));
@@ -711,16 +716,16 @@ public class VRSettings {
             if (mapping == null) {
                 return;
             }
-            Field field = mapping.getLeft();
+            Field field = mapping.field;
             Class<?> type = field.getType();
-            String name = mapping.getMiddle();
+            String name = mapping.configName;
 
             Map<String, String> profileSet = ProfileManager.getProfileSet(this.defaults, ProfileManager.PROFILE_SET_VR);
 
             if (type.isArray()) {
                 Object arr = field.get(this);
                 int len = Array.getLength(arr);
-                if (mapping.getRight()) {
+                if (mapping.separate) {
                     for (int i = 0; i < len; i++) {
                         Object obj = Objects.requireNonNull(loadDefault(name + "_" + i, null, option, type.getComponentType(), false, profileSet));
                         Array.set(arr, i, obj);
@@ -734,7 +739,7 @@ public class VRSettings {
                     }
                 }
             } else {
-                Object obj = Objects.requireNonNull(loadDefault(name, null, option, type, mapping.getRight(), profileSet));
+                Object obj = Objects.requireNonNull(loadDefault(name, null, option, type, mapping.separate, profileSet));
                 field.set(this, obj);
             }
         } catch (Exception ex) {
@@ -769,24 +774,31 @@ public class VRSettings {
                         continue;
                     }
 
-                    Field field = mapping.getLeft();
+                    Field field = mapping.field;
                     Class<?> type = field.getType();
                     Object currentValue = field.get(this);
                     if (type.isArray()) {
-                        if (mapping.getRight()) {
+                        if (mapping.separate) {
                             int index = Integer.parseInt(name.substring(name.lastIndexOf('_') + 1));
-                            Object obj = Objects.requireNonNull(loadOption(name.substring(0, name.lastIndexOf('_')), value, Array.get(currentValue, index), mapping.getMiddle(), type.getComponentType(), false));
+                            Object obj = Objects.requireNonNull(loadOption(name.substring(0, name.lastIndexOf('_')), value, Array.get(currentValue, index), mapping.vrOptions, type.getComponentType(), false));
                             Array.set(currentValue, index, obj);
                         } else {
                             int len = Array.getLength(currentValue);
                             String[] split = value.split(";", -1); // Avoid conflicting with other comma-delimited types
+                            if (split.length != len && !mapping.fixedSize) {
+                                Object newValue = Array.newInstance(type.getComponentType(), split.length);
+                                System.arraycopy(currentValue, 0, newValue, 0, Math.min(len, split.length));
+                                field.set(this, newValue);
+                                currentValue = newValue;
+                                len = split.length;
+                            }
                             for (int i = 0; i < len; i++) {
-                                Object obj = Objects.requireNonNull(loadOption(name, split[i], Array.get(currentValue, i), mapping.getMiddle(), type.getComponentType(), false));
+                                Object obj = Objects.requireNonNull(loadOption(name, split[i], Array.get(currentValue, i), mapping.vrOptions, type.getComponentType(), false));
                                 Array.set(currentValue, i, obj);
                             }
                         }
                     } else {
-                        Object obj = Objects.requireNonNull(loadOption(name, value, currentValue, mapping.getMiddle(), type, mapping.getRight()));
+                        Object obj = Objects.requireNonNull(loadOption(name, value, currentValue, mapping.vrOptions, type, mapping.separate));
                         field.set(this, obj);
                     }
                 } catch (Exception var7) {
@@ -822,27 +834,27 @@ public class VRSettings {
             for (var entry : fieldConfigMap.entrySet()) {
                 String name = entry.getKey();
                 var mapping = entry.getValue();
-                Field field = mapping.getLeft();
+                Field field = mapping.field;
                 Class<?> type = field.getType();
                 Object obj = field.get(this);
 
                 try {
                     if (type.isArray()) {
-                        if (mapping.getRight()) {
+                        if (mapping.separate) {
                             int index = Integer.parseInt(name.substring(name.lastIndexOf('_') + 1));
-                            String value = Objects.requireNonNull(saveOption(name.substring(0, name.lastIndexOf('_')), Array.get(obj, index), mapping.getMiddle(), type.getComponentType(), mapping.getRight()));
+                            String value = Objects.requireNonNull(saveOption(name.substring(0, name.lastIndexOf('_')), Array.get(obj, index), mapping.vrOptions, type.getComponentType(), mapping.separate));
                             var5.println(name + ":" + value);
                         } else {
                             StringJoiner joiner = new StringJoiner(";");
                             int len = Array.getLength(obj);
                             for (int i = 0; i < len; i++) {
-                                String value = Objects.requireNonNull(saveOption(name, Array.get(obj, i), mapping.getMiddle(), type.getComponentType(), mapping.getRight()));
+                                String value = Objects.requireNonNull(saveOption(name, Array.get(obj, i), mapping.vrOptions, type.getComponentType(), mapping.separate));
                                 joiner.add(value);
                             }
                             var5.println(name + ":" + joiner);
                         }
                     } else {
-                        String value = Objects.requireNonNull(saveOption(name, obj, mapping.getMiddle(), type, mapping.getRight()));
+                        String value = Objects.requireNonNull(saveOption(name, obj, mapping.vrOptions, type, mapping.separate));
                         var5.println(name + ":" + value);
                     }
                 } catch (Exception ex) {
@@ -875,7 +887,7 @@ public class VRSettings {
             if (mapping == null) {
                 return var2;
             }
-            Field field = mapping.getLeft();
+            Field field = mapping.field;
             Class<?> type = field.getType();
 
             Object obj = field.get(this);
@@ -914,7 +926,7 @@ public class VRSettings {
             if (mapping == null) {
                 return 0;
             }
-            Field field = mapping.getLeft();
+            Field field = mapping.field;
 
             float value = ((Number) field.get(this)).floatValue();
             if (overrides.hasSetting(par1EnumOptions)) {
@@ -939,7 +951,7 @@ public class VRSettings {
             if (mapping == null) {
                 return;
             }
-            Field field = mapping.getLeft();
+            Field field = mapping.field;
             Class<?> type = field.getType();
 
             Object obj = par1EnumOptions.setOptionValue(field.get(this));
@@ -950,7 +962,7 @@ public class VRSettings {
             } else if (OptionEnum.class.isAssignableFrom(type)) {
                 field.set(this, ((OptionEnum<?>) field.get(this)).getNext());
             } else {
-                logger.warn("Don't know how to set VR option " + mapping.getMiddle() + " with type " + type.getSimpleName());
+                logger.warn("Don't know how to set VR option " + mapping.configName + " with type " + type.getSimpleName());
                 return;
             }
 
@@ -968,7 +980,7 @@ public class VRSettings {
             if (mapping == null) {
                 return;
             }
-            Field field = mapping.getLeft();
+            Field field = mapping.field;
             Class<?> type = field.getType();
 
             float f = Objects.requireNonNullElse(par1EnumOptions.setOptionFloatValue(par2), par2);
@@ -1006,6 +1018,7 @@ public class VRSettings {
         //return this.headTrackSensitivity;  // TODO: If head track sensitivity is working again... if
     }
 
+    record ConfigEntry(Field field, VrOptions vrOptions, String configName, boolean separate, boolean fixedSize) { }
 
     public enum VrOptions {
         DUMMY(false, true), // Dummy
@@ -1148,6 +1161,7 @@ public class VRSettings {
             }
         },
         PHYSICAL_KEYBOARD_THEME(false, false), // Keyboard Theme
+        KEYBOARD_PRESS_BINDS(false, true), // Keyboard Presses Bindings
         GUI_APPEAR_OVER_BLOCK(false, true), // Appear Over Block
         SHADER_GUI_RENDER(false, true),
         //HMD/render
@@ -1978,6 +1992,66 @@ public class VRSettings {
         out[5] = "";
         out[6] = "";
         out[7] = "";
+
+        return out;
+    }
+
+    public int[] getKeyboardCodesDefault() {
+        // Some keys in the in-game keyboard don't have assignable key codes
+        int[] out = new int[] {
+            GLFW.GLFW_KEY_GRAVE_ACCENT,
+            GLFW.GLFW_KEY_1,
+            GLFW.GLFW_KEY_2,
+            GLFW.GLFW_KEY_3,
+            GLFW.GLFW_KEY_4,
+            GLFW.GLFW_KEY_5,
+            GLFW.GLFW_KEY_6,
+            GLFW.GLFW_KEY_7,
+            GLFW.GLFW_KEY_8,
+            GLFW.GLFW_KEY_9,
+            GLFW.GLFW_KEY_0,
+            GLFW.GLFW_KEY_MINUS,
+            GLFW.GLFW_KEY_EQUAL,
+            GLFW.GLFW_KEY_Q,
+            GLFW.GLFW_KEY_W,
+            GLFW.GLFW_KEY_E,
+            GLFW.GLFW_KEY_R,
+            GLFW.GLFW_KEY_T,
+            GLFW.GLFW_KEY_Y,
+            GLFW.GLFW_KEY_U,
+            GLFW.GLFW_KEY_I,
+            GLFW.GLFW_KEY_O,
+            GLFW.GLFW_KEY_P,
+            GLFW.GLFW_KEY_LEFT_BRACKET,
+            GLFW.GLFW_KEY_RIGHT_BRACKET,
+            GLFW.GLFW_KEY_BACKSLASH,
+            GLFW.GLFW_KEY_A,
+            GLFW.GLFW_KEY_S,
+            GLFW.GLFW_KEY_D,
+            GLFW.GLFW_KEY_F,
+            GLFW.GLFW_KEY_G,
+            GLFW.GLFW_KEY_H,
+            GLFW.GLFW_KEY_J,
+            GLFW.GLFW_KEY_K,
+            GLFW.GLFW_KEY_L,
+            GLFW.GLFW_KEY_SEMICOLON,
+            GLFW.GLFW_KEY_APOSTROPHE,
+            GLFW.GLFW_KEY_UNKNOWN, // colon
+            GLFW.GLFW_KEY_UNKNOWN, // quote
+            GLFW.GLFW_KEY_Z,
+            GLFW.GLFW_KEY_X,
+            GLFW.GLFW_KEY_C,
+            GLFW.GLFW_KEY_V,
+            GLFW.GLFW_KEY_B,
+            GLFW.GLFW_KEY_N,
+            GLFW.GLFW_KEY_M,
+            GLFW.GLFW_KEY_COMMA,
+            GLFW.GLFW_KEY_PERIOD,
+            GLFW.GLFW_KEY_SLASH,
+            GLFW.GLFW_KEY_UNKNOWN, // question mark
+            GLFW.GLFW_KEY_UNKNOWN, // less than
+            GLFW.GLFW_KEY_UNKNOWN // greater than
+        };
 
         return out;
     }

--- a/common/src/main/resources/assets/vivecraft/lang/en_us.json
+++ b/common/src/main/resources/assets/vivecraft/lang/en_us.json
@@ -170,6 +170,7 @@
   "vivecraft.options.HANDHELD_CAMERA_RENDER_SCALE": "Camera Resolution",
   "vivecraft.options.MIXED_REALITY_RENDER_CAMERA_MODEL": "Show Camera Model",
   "vivecraft.options.PHYSICAL_KEYBOARD_THEME": "Keyboard Theme",
+  "vivecraft.options.KEYBOARD_PRESS_BINDS": "Keyboard Presses Bindings",
   "_comment6": "Option tooltips",
   "vivecraft.options.HUD_SCALE.tooltip": "Relative size HUD takes up in field-of-view.\nThe units are just relative, not in degrees or a fraction of FOV or anything.",
   "vivecraft.options.HUD_DISTANCE.tooltip": "Distance the floating HUD is drawn in front of your body.\nThe relative size of the HUD is unchanged by this.\nDistance is in meters (though isn't obstructed by blocks).",
@@ -257,6 +258,7 @@
   "vivecraft.options.HANDHELD_CAMERA_RENDER_SCALE.tooltip": "Resolution of the handheld screenshot camera, for taking screenshots much larger than normal render resolution.\nCannot be used when shaders are enabled.\n§cWARNING: Setting this very high may melt your computer!",
   "vivecraft.options.MIXED_REALITY_RENDER_CAMERA_MODEL.tooltip": "Show model of a video camera (only in HMD view) to represent where the mixed reality or third person camera is currently located. It can also be grabbed to move it around using the interact binding.",
   "vivecraft.options.PHYSICAL_KEYBOARD_THEME.tooltip": "Color scheme preset for the physical keyboard. Custom theme can be edited via keyboardtheme.txt in the game directory. It will be reloaded every time the keyboard is opened, to allow real-time tweaking.",
+  "vivecraft.options.KEYBOARD_PRESS_BINDS.tooltip": "Whether the keyboard should activate key bindings when typing into thin air.\nBe careful! You might activate things you don't intend to.",
   "_comment7": "Option values",
   "vivecraft.options.gamma.cantseeshitcaptain": "I Can't See",
   "vivecraft.options.yes": "YES",
@@ -379,6 +381,7 @@
   "vivecraft.messages.coords": "X: %.2f Y: %.2f Z: %.2f",
   "vivecraft.messages.angles": "Pitch: %.1f Yaw: %.1f Roll: %.1f",
   "vivecraft.messages.heightset": "User height set to %d%%",
+  "vivecraft.messages.airtypingwarning": "You are typing without a screen open. If you're trying to use key bindings, enable \"Keyboard Presses Bindings\" in the VR settings.",
 
   "_comment_m": "mixin version exclusive strings",
   "vivecraft.options.screen.settings": "Vivecraft Settings",


### PR DESCRIPTION
Disabled by default, since I think it could be bad UX if someone accidentally activates bindings they don't intend to. We can always change it if we determine otherwise. If disabled, a message will pop up in chat when you type without a screen open.

I also included a small refactor of VRSettings for code clarity and some additional functionality.