### PR TITLE
Set action manifest langauge_tag to current language code instead of en_US

### DIFF
--- a/common/src/main/java/org/vivecraft/client_vr/provider/openvr_lwjgl/MCOpenVR.java
+++ b/common/src/main/java/org/vivecraft/client_vr/provider/openvr_lwjgl/MCOpenVR.java
@@ -474,7 +474,7 @@ public class MCOpenVR extends MCVR {
         map1.put(ACTION_EXTERNAL_CAMERA, "External Camera");
         map1.put(ACTION_LEFT_HAPTIC, "Left Hand Haptic");
         map1.put(ACTION_RIGHT_HAPTIC, "Right Hand Haptic");
-        map1.put("language_tag", "en_US");
+        map1.put("language_tag", mc.options.languageCode.substring(0, mc.options.languageCode.indexOf('_')) + mc.options.languageCode.substring(mc.options.languageCode.indexOf('_')).toUpperCase());
         map.put("localization", ImmutableList.<Map<String, Object>>builder().add(map1).build());
         List<Map<String, Object>> list3 = new ArrayList<>();
         list3.add(ImmutableMap.<String, Object>builder().put("controller_type", "vive_controller").put("binding_url", "vive_defaults.json").build());


### PR DESCRIPTION
Slightly improves behavior due to SteamVR not falling back to english strings when a different language is selected in Steam. Valve pls fix.