### PR TITLE
Set BufferBuilder buffer to null after freeing

### DIFF
--- a/common/src/main/java/org/vivecraft/mixin/client/blaze3d/BufferBuilderMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/blaze3d/BufferBuilderMixin.java
@@ -16,6 +16,7 @@ public class BufferBuilderMixin implements BufferBuilderExtension {
     @Override
     public void vivecraft$freeBuffer() {
         MemoryTrackerAccessor.getAllocator().free(MemoryUtil.memAddress0(buffer));
+        buffer = null;
     }
 
     @Override


### PR DESCRIPTION
Resolves double free heap corruption with ModernFix. 😬