### PR TITLE
Make self butt sparkles invisible in HMD and first person views

### DIFF
--- a/common/src/main/java/org/vivecraft/client/VRPlayersClient.java
+++ b/common/src/main/java/org/vivecraft/client/VRPlayersClient.java
@@ -6,6 +6,7 @@ import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
+import org.vivecraft.client.extensions.SparkParticleExtension;
 import org.vivecraft.client.utils.Utils;
 import org.vivecraft.client_vr.ClientDataHolderVR;
 import org.vivecraft.client_vr.VRData;
@@ -149,6 +150,7 @@ public class VRPlayersClient {
 
                         if (particle != null) {
                             particle.setColor(0.5F + this.rand.nextFloat() / 2.0F, 0.5F + this.rand.nextFloat() / 2.0F, 0.5F + this.rand.nextFloat() / 2.0F);
+                            ((SparkParticleExtension)particle).vivecraft$setPlayerUUID(player.getUUID());
                         }
                     }
                 }

--- a/common/src/main/java/org/vivecraft/client/extensions/SparkParticleExtension.java
+++ b/common/src/main/java/org/vivecraft/client/extensions/SparkParticleExtension.java
@@ -1,0 +1,7 @@
+package org.vivecraft.client.extensions;
+
+import java.util.UUID;
+
+public interface SparkParticleExtension {
+    void vivecraft$setPlayerUUID(UUID playerUUID);
+}

--- a/common/src/main/java/org/vivecraft/client_vr/settings/VRSettings.java
+++ b/common/src/main/java/org/vivecraft/client_vr/settings/VRSettings.java
@@ -448,6 +448,8 @@ public class VRSettings {
     public boolean vrSettingsButtonPositionLeft = true;
     @SettingField
     public boolean disableGarbageCollectorMessage = false;
+    @SettingField
+    public boolean selfButtSparklesInFirstPerson = false;
 
     /**
      * This isn't actually used, it's only a dummy field to save the value from vanilla Options.

--- a/common/src/main/java/org/vivecraft/mixin/client/particle/SparkParticleMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client/particle/SparkParticleMixin.java
@@ -1,0 +1,36 @@
+package org.vivecraft.mixin.client.particle;
+
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.Camera;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.vivecraft.client.extensions.SparkParticleExtension;
+import org.vivecraft.client_vr.ClientDataHolderVR;
+import org.vivecraft.client_vr.VRState;
+import org.vivecraft.client_vr.render.RenderPass;
+
+import java.util.UUID;
+import java.util.stream.Stream;
+
+@Mixin(targets = "net.minecraft.client.particle.FireworkParticles$SparkParticle")
+public class SparkParticleMixin implements SparkParticleExtension {
+    @Unique
+    private UUID vivecraft$playerUUID;
+
+    @Inject(at = @At("HEAD"), method = "render", cancellable = true)
+    private void vivecraft$hideSelfButtSparkles(VertexConsumer vertexConsumer, Camera camera, float f, CallbackInfo ci) {
+        if (!ClientDataHolderVR.getInstance().vrSettings.selfButtSparklesInFirstPerson
+            && camera.getEntity().getUUID().equals(this.vivecraft$playerUUID) && ((!VRState.vrRunning && !camera.isDetached())
+            || (VRState.vrRunning && Stream.of(RenderPass.LEFT, RenderPass.RIGHT, RenderPass.CENTER).anyMatch(pass -> ClientDataHolderVR.getInstance().currentPass == pass)))) {
+            ci.cancel();
+        }
+    }
+
+    @Override
+    public void vivecraft$setPlayerUUID(UUID playerUUID) {
+        this.vivecraft$playerUUID = playerUUID;
+    }
+}

--- a/common/src/main/resources/vivecraft.mixins.json
+++ b/common/src/main/resources/vivecraft.mixins.json
@@ -12,6 +12,7 @@
     "client.gui.screens.ScreenMixin",
     "client.gui.screens.TitleScreenMixin",
     "client.main.MainMixin",
+    "client.particle.SparkParticleMixin",
     "client.player.AbstractClientPlayerMixin",
     "client.renderer.ItemBlockRenderTypesMixin",
     "client.renderer.RenderStateShardAccessor",


### PR DESCRIPTION
They can be extremely distracting when trying to look down in dark rooms, especially due to headset lens god rays.