### PR TITLE
Some Immersive Portals Fixes

### DIFF
--- a/common/src/main/java/org/vivecraft/client/render/VRPlayerRenderer.java
+++ b/common/src/main/java/org/vivecraft/client/render/VRPlayerRenderer.java
@@ -10,8 +10,10 @@ import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.entity.player.PlayerRenderer;
 import net.minecraft.world.phys.Vec3;
 import org.vivecraft.client.VRPlayersClient;
+import org.vivecraft.client.Xplat;
 import org.vivecraft.client_vr.ClientDataHolderVR;
 import org.vivecraft.client_vr.render.RenderPass;
+import org.vivecraft.mod_compat_vr.immersiveportals.ImmersivePortalsHelper;
 
 import java.util.UUID;
 
@@ -36,7 +38,10 @@ public class VRPlayerRenderer extends PlayerRenderer {
 
     @Override
     public void render(AbstractClientPlayer entityIn, float pEntityYaw, float pPartialTicks, PoseStack matrixStackIn, MultiBufferSource pBuffer, int pPackedLight) {
-
+        if (Xplat.isModLoaded("immersive_portals") && entityIn == Minecraft.getInstance().player
+            && ImmersivePortalsHelper.isStandingInPortal()) {
+            return;
+        }
         VRPlayersClient.RotInfo playermodelcontroller$rotinfo = VRPlayersClient.getInstance().getRotationsForPlayer(entityIn.getUUID());
 
         if (playermodelcontroller$rotinfo != null) {

--- a/common/src/main/java/org/vivecraft/client_vr/render/helpers/VREffectsHelper.java
+++ b/common/src/main/java/org/vivecraft/client_vr/render/helpers/VREffectsHelper.java
@@ -19,6 +19,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
@@ -70,15 +71,17 @@ public class VREffectsHelper {
     }
 
     public static Triple<Float, BlockState, BlockPos> getNearOpaqueBlock(Vec3 in, double dist) {
-        if (mc.level == null) {
+        // Prefer mc.player.level() to prevent getting the head stuck in block with ImmersivePortals.
+        Level level = mc.player != null && mc.player.level() != null ? mc.player.level() : mc.level;
+        if (level == null) {
             return null;
         } else {
             AABB aabb = new AABB(in.subtract(dist, dist, dist), in.add(dist, dist, dist));
             Stream<BlockPos> stream = BlockPos.betweenClosedStream(aabb).filter((bp) ->
-                mc.level.getBlockState(bp).isSolidRender(mc.level, bp));
+                level.getBlockState(bp).isSolidRender(level, bp));
             Optional<BlockPos> optional = stream.findFirst();
             return optional.isPresent()
-                   ? Triple.of(1.0F, mc.level.getBlockState(optional.get()), optional.get())
+                   ? Triple.of(1.0F, level.getBlockState(optional.get()), optional.get())
                    : null;
         }
     }

--- a/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/ImmersivePortalsHelper.java
+++ b/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/ImmersivePortalsHelper.java
@@ -4,6 +4,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.AABB;
 import qouteall.imm_ptl.core.IPGlobal;
+import qouteall.imm_ptl.core.portal.Mirror;
 import qouteall.imm_ptl.core.portal.Portal;
 import qouteall.imm_ptl.core.render.context_management.PortalRendering;
 
@@ -19,6 +20,6 @@ public class ImmersivePortalsHelper {
     public static boolean isStandingInPortal() {
         Player player = Minecraft.getInstance().player;
         return !player.level().getEntities(player, AABB.ofSize(player.position(), 0.1, 0.1, 0.1),
-            (entity -> entity instanceof Portal)).isEmpty();
+            (entity -> entity instanceof Portal && !(entity instanceof Mirror))).isEmpty();
     }
 }

--- a/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/ImmersivePortalsHelper.java
+++ b/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/ImmersivePortalsHelper.java
@@ -1,6 +1,10 @@
 package org.vivecraft.mod_compat_vr.immersiveportals;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.phys.AABB;
 import qouteall.imm_ptl.core.IPGlobal;
+import qouteall.imm_ptl.core.portal.Portal;
 import qouteall.imm_ptl.core.render.context_management.PortalRendering;
 
 public class ImmersivePortalsHelper {
@@ -10,5 +14,11 @@ public class ImmersivePortalsHelper {
 
     public static boolean shouldRenderSelf() {
         return IPGlobal.renderYourselfInPortal && isRenderingPortal();
+    }
+
+    public static boolean isStandingInPortal() {
+        Player player = Minecraft.getInstance().player;
+        return !player.level().getEntities(player, AABB.ofSize(player.position(), 0.1, 0.1, 0.1),
+            (entity -> entity instanceof Portal)).isEmpty();
     }
 }

--- a/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/mixin/ClientTeleportationManagerMixin.java
+++ b/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/mixin/ClientTeleportationManagerMixin.java
@@ -1,0 +1,26 @@
+package org.vivecraft.mod_compat_vr.immersiveportals.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import qouteall.imm_ptl.core.portal.Portal;
+import qouteall.imm_ptl.core.teleportation.ClientTeleportationManager;
+import qouteall.imm_ptl.core.teleportation.TeleportationUtil;
+
+@Mixin(ClientTeleportationManager.class)
+public class ClientTeleportationManagerMixin {
+    @Shadow
+    private static long lastTeleportGameTime;
+
+    @Shadow
+    public static long tickTimeForTeleportation;
+
+    @Inject(method = "teleportPlayer", at = @At("HEAD"), remap = false, cancellable = true)
+    private static void onlyOneTpPerFrame(TeleportationUtil.Teleportation teleportation, float partialTicks, CallbackInfo ci) {
+        if (lastTeleportGameTime == tickTimeForTeleportation) {
+            ci.cancel();
+        }
+    }
+}

--- a/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/mixin/CrossPortalViewRenderingMixin.java
+++ b/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/mixin/CrossPortalViewRenderingMixin.java
@@ -14,16 +14,16 @@ import qouteall.imm_ptl.core.teleportation.ClientTeleportationManager;
 @Mixin(CrossPortalViewRendering.class)
 public class CrossPortalViewRenderingMixin {
 
-    @Redirect(method = "renderCrossPortalView", at = @At(value = "INVOKE", target = "Lqouteall/imm_ptl/core/teleportation/ClientTeleportationManager;getPlayerEyePos(F)Lnet/minecraft/world/phys/Vec3;"), remap = false)
-    private static Vec3 getPlayerEyePos(float partialTick) {
+    @Redirect(method = "renderCrossPortalView", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Camera;getPosition()Lnet/minecraft/world/phys/Vec3;"), remap = false)
+    private static Vec3 getPlayerCameraPos(Camera camera) {
         if (VRState.vrRunning && ClientDataHolderVR.getInstance() != null && VRPlayer.get() != null) {
             return VRPlayer.get().vrdata_world_render.getEye(ClientDataHolderVR.getInstance().currentPass).getPosition();
         }
-        return ClientTeleportationManager.getPlayerEyePos(partialTick);
+        return camera.getPosition();
     }
 
-    @Redirect(method = "renderCrossPortalView", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Camera;getPosition()Lnet/minecraft/world/phys/Vec3;"), remap = false)
-    private static Vec3 getPlayerCameraPos(Camera camera) {
+    @Redirect(method = "renderCrossPortalView", at = @At(value = "INVOKE", target = "Lqouteall/imm_ptl/core/render/TransformationManager;getIsometricAdjustedCameraPos(Lnet/minecraft/client/Camera;)Lnet/minecraft/world/phys/Vec3;"), remap = false)
+    private static Vec3 getPlayerCameraPos2(Camera camera) {
         if (VRState.vrRunning && ClientDataHolderVR.getInstance() != null && VRPlayer.get() != null) {
             return VRPlayer.get().vrdata_world_render.getEye(ClientDataHolderVR.getInstance().currentPass).getPosition();
         }

--- a/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/mixin/CrossPortalViewRenderingMixin.java
+++ b/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/mixin/CrossPortalViewRenderingMixin.java
@@ -1,0 +1,32 @@
+package org.vivecraft.mod_compat_vr.immersiveportals.mixin;
+
+import net.minecraft.client.Camera;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.vivecraft.client_vr.ClientDataHolderVR;
+import org.vivecraft.client_vr.VRState;
+import org.vivecraft.client_vr.gameplay.VRPlayer;
+import qouteall.imm_ptl.core.render.CrossPortalViewRendering;
+import qouteall.imm_ptl.core.teleportation.ClientTeleportationManager;
+
+@Mixin(CrossPortalViewRendering.class)
+public class CrossPortalViewRenderingMixin {
+
+    @Redirect(method = "renderCrossPortalView", at = @At(value = "INVOKE", target = "Lqouteall/imm_ptl/core/teleportation/ClientTeleportationManager;getPlayerEyePos(F)Lnet/minecraft/world/phys/Vec3;"), remap = false)
+    private static Vec3 getPlayerEyePos(float partialTick) {
+        if (VRState.vrRunning && ClientDataHolderVR.getInstance() != null && VRPlayer.get() != null) {
+            return VRPlayer.get().vrdata_world_render.getEye(ClientDataHolderVR.getInstance().currentPass).getPosition();
+        }
+        return ClientTeleportationManager.getPlayerEyePos(partialTick);
+    }
+
+    @Redirect(method = "renderCrossPortalView", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Camera;getPosition()Lnet/minecraft/world/phys/Vec3;"), remap = false)
+    private static Vec3 getPlayerCameraPos(Camera camera) {
+        if (VRState.vrRunning && ClientDataHolderVR.getInstance() != null && VRPlayer.get() != null) {
+            return VRPlayer.get().vrdata_world_render.getEye(ClientDataHolderVR.getInstance().currentPass).getPosition();
+        }
+        return camera.getPosition();
+    }
+}

--- a/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/mixin/McHelperMixin.java
+++ b/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/mixin/McHelperMixin.java
@@ -14,8 +14,10 @@ public class McHelperMixin {
 
     @Inject(at = @At("HEAD"), method = "updateBoundingBox")
     private static void updateBoundingBox(Entity player, CallbackInfo ci) {
-        Vec3 newPos = player.position();
-        VRPlayer.get().setRoomOrigin(newPos.x, newPos.y, newPos.z, true);
+        if (VRPlayer.get() != null) {
+            Vec3 newPos = player.position();
+            VRPlayer.get().setRoomOrigin(newPos.x, newPos.y, newPos.z, true);
+        }
     }
 
 }

--- a/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/mixin/McHelperMixin.java
+++ b/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/mixin/McHelperMixin.java
@@ -1,0 +1,21 @@
+package org.vivecraft.mod_compat_vr.immersiveportals.mixin;
+
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.vivecraft.client_vr.gameplay.VRPlayer;
+import qouteall.imm_ptl.core.McHelper;
+
+@Mixin(McHelper.class)
+public class McHelperMixin {
+
+    @Inject(at = @At("HEAD"), method = "updateBoundingBox")
+    private static void updateBoundingBox(Entity player, CallbackInfo ci) {
+        Vec3 newPos = player.position();
+        VRPlayer.get().setRoomOrigin(newPos.x, newPos.y, newPos.z, true);
+    }
+
+}

--- a/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/mixin/McHelperMixin.java
+++ b/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/mixin/McHelperMixin.java
@@ -16,6 +16,10 @@ public class McHelperMixin {
     private static void updateBoundingBox(Entity player, CallbackInfo ci) {
         if (VRPlayer.get() != null) {
             Vec3 newPos = player.position();
+            Vec3 offset = newPos.subtract(VRPlayer.get().roomOrigin);
+            VRPlayer.get().vrdata_world_render.origin = VRPlayer.get().vrdata_world_render.origin.add(offset);
+            VRPlayer.get().vrdata_world_pre.origin = VRPlayer.get().vrdata_world_pre.origin.add(offset);
+            VRPlayer.get().vrdata_world_post.origin = VRPlayer.get().vrdata_world_post.origin.add(offset);
             VRPlayer.get().setRoomOrigin(newPos.x, newPos.y, newPos.z, true);
         }
     }

--- a/common/src/main/resources/vivecraft.immersiveportals.mixins.json
+++ b/common/src/main/resources/vivecraft.immersiveportals.mixins.json
@@ -1,0 +1,10 @@
+{
+  "required": false,
+  "package": "org.vivecraft.mod_compat_vr.immersiveportals.mixin",
+  "plugin": "org.vivecraft.MixinConfig",
+  "compatibilityLevel": "JAVA_17",
+  "client": [
+    "McHelperMixin"
+  ],
+  "minVersion": "0.8.4"
+}

--- a/common/src/main/resources/vivecraft.immersiveportals.mixins.json
+++ b/common/src/main/resources/vivecraft.immersiveportals.mixins.json
@@ -4,6 +4,8 @@
   "plugin": "org.vivecraft.MixinConfig",
   "compatibilityLevel": "JAVA_17",
   "client": [
+    "ClientTeleportationManagerMixin",
+    "CrossPortalViewRenderingMixin",
     "McHelperMixin"
   ],
   "minVersion": "0.8.4"

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -35,6 +35,7 @@
     "vivecraft.dynamicfps.mixins.json",
     "vivecraft.sodium.mixins.json",
     "vivecraft.fabric.sodium.mixins.json",
+    "vivecraft.immersiveportals.mixins.json",
     "vivecraft.iris.mixins.json",
     "vivecraft.modmenu.mixins.json",
     "vivecraft.physicsmod.mixins.json",

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -21,6 +21,7 @@ loom {
         mixinConfig "vivecraft.sodium.mixins.json"
         mixinConfig "vivecraft.forge.sodium.mixins.json"
         mixinConfig "vivecraft.iris.mixins.json"
+        mixinConfig "vivecraft.immersiveportals.mixins.json"
         mixinConfig "vivecraft.physicsmod.mixins.json"
         mixinConfig "vivecraft.rei.mixins.json"
         mixinConfig "vivecraft.resolutioncontrol.mixins.json"


### PR DESCRIPTION
This fixes a few issues with Immersive Portals while still leaving some behind:

- Fixes teleportation failing when positions don't line up between dimensions. This should work on ImmersivePortals 3.3.1 and higher.
- Fixes several rendering issues, partly using some weird hacks. From my testing, this only works on ImmersivePortals 3.3.1. **EDIT: For some reason, this only works in dev.**

Issues that still remain:

- Portals that change player orientation still don't work. Considering the vanilla `/tp` command also can't rotate the player, I don't consider this to be a showstopper. Would be nice to see it fixed, though.
- As mentioned above, the fixes to rendering issues don't work on ImmersivePortals 3.3.8. Couldn't debug those since getting ImmersivePortals up to 3.3.8 on Vivecraft requires an Iris upgrade, which by extension, requires updating Sodium and Indium as well. All of that makes it so we'd also have to upgrade our loom version for whatever reason.
- The view "jumps back" a little bit when teleporting. You may also still see a flash when teleporting, but from what I can tell, that's moreso for chunks loading than anything else.

What makes this PR so hack-y:
- Mixing into ImmersivePortals probably isn't great, especially with how different their internals can be between versions. These fixes might work for Minecraft 1.20.4, and likely will NOT work for Minecraft 1.18.2.
- Due to the "jumping back" of the view mentioned above (I believe it's due to the jumping back, anyways), the player model of oneself would usually be rendered. To bypass this, I simply disable rendering the player's VR view if within 0.1 blocks of an ImmersivePortals portal entity.

From testing, this does not cause any issues in an environment without ImmersivePortals.

With the fact that the rendering issues still persist in prod and that they only work for one version in dev, I'd wager to not include those and only take the teleportation fixes.