### PR TITLE
[1.20.4] Some Immersive Portals Fixes

### DIFF
--- a/common/src/main/java/org/vivecraft/client_vr/render/helpers/VREffectsHelper.java
+++ b/common/src/main/java/org/vivecraft/client_vr/render/helpers/VREffectsHelper.java
@@ -19,6 +19,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
@@ -70,15 +71,17 @@ public class VREffectsHelper {
     }
 
     public static Triple<Float, BlockState, BlockPos> getNearOpaqueBlock(Vec3 in, double dist) {
-        if (mc.level == null) {
+        // Prefer mc.player.level() to prevent getting the head stuck in block with ImmersivePortals.
+        Level level = mc.player != null && mc.player.level() != null ? mc.player.level() : mc.level;
+        if (level == null) {
             return null;
         } else {
             AABB aabb = new AABB(in.subtract(dist, dist, dist), in.add(dist, dist, dist));
             Stream<BlockPos> stream = BlockPos.betweenClosedStream(aabb).filter((bp) ->
-                mc.level.getBlockState(bp).isSolidRender(mc.level, bp));
+                level.getBlockState(bp).isSolidRender(level, bp));
             Optional<BlockPos> optional = stream.findFirst();
             return optional.isPresent()
-                   ? Triple.of(1.0F, mc.level.getBlockState(optional.get()), optional.get())
+                   ? Triple.of(1.0F, level.getBlockState(optional.get()), optional.get())
                    : null;
         }
     }

--- a/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/mixin/McHelperMixin.java
+++ b/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/mixin/McHelperMixin.java
@@ -14,8 +14,10 @@ public class McHelperMixin {
 
     @Inject(at = @At("HEAD"), method = "updateBoundingBox")
     private static void updateBoundingBox(Entity player, CallbackInfo ci) {
-        Vec3 newPos = player.position();
-        VRPlayer.get().setRoomOrigin(newPos.x, newPos.y, newPos.z, true);
+        if (VRPlayer.get() != null) {
+            Vec3 newPos = player.position();
+            VRPlayer.get().setRoomOrigin(newPos.x, newPos.y, newPos.z, true);
+        }
     }
 
 }

--- a/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/mixin/McHelperMixin.java
+++ b/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/mixin/McHelperMixin.java
@@ -1,0 +1,21 @@
+package org.vivecraft.mod_compat_vr.immersiveportals.mixin;
+
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.vivecraft.client_vr.gameplay.VRPlayer;
+import qouteall.imm_ptl.core.McHelper;
+
+@Mixin(McHelper.class)
+public class McHelperMixin {
+
+    @Inject(at = @At("HEAD"), method = "updateBoundingBox")
+    private static void updateBoundingBox(Entity player, CallbackInfo ci) {
+        Vec3 newPos = player.position();
+        VRPlayer.get().setRoomOrigin(newPos.x, newPos.y, newPos.z, true);
+    }
+
+}

--- a/common/src/main/resources/vivecraft.immersiveportals.mixins.json
+++ b/common/src/main/resources/vivecraft.immersiveportals.mixins.json
@@ -1,0 +1,10 @@
+{
+  "required": false,
+  "package": "org.vivecraft.mod_compat_vr.immersiveportals.mixin",
+  "plugin": "org.vivecraft.MixinConfig",
+  "compatibilityLevel": "JAVA_17",
+  "client": [
+    "McHelperMixin"
+  ],
+  "minVersion": "0.8.4"
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -36,6 +36,7 @@
     "vivecraft.dynamicfps.mixins.json",
     "vivecraft.sodium.mixins.json",
     "vivecraft.fabric.sodium.mixins.json",
+    "vivecraft.immersiveportals.mixins.json",
     "vivecraft.iris.mixins.json",
     "vivecraft.modmenu.mixins.json",
     "vivecraft.physicsmod.mixins.json",

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -22,6 +22,7 @@ loom {
         mixinConfig "vivecraft.sodium.mixins.json"
         mixinConfig "vivecraft.forge.sodium.mixins.json"
         mixinConfig "vivecraft.iris.mixins.json"
+        mixinConfig "vivecraft.immersiveportals.mixins.json"
         mixinConfig "vivecraft.physicsmod.mixins.json"
         mixinConfig "vivecraft.rei.mixins.json"
         mixinConfig "vivecraft.resolutioncontrol.mixins.json"


### PR DESCRIPTION
Port to 1.20.4 of #246 with the not-really-working rendering fixes not included.

This PR fixes a few issues with Immersive Portals while still leaving some behind:

- Fixes teleportation failing when positions don't line up between dimensions.
- Fixes the "head stuck in block" effect when rendering an ImmersivePortals portal.

Issues that still remain:

- Portals that change player orientation still don't work. Considering the vanilla `/tp` command also can't rotate the player, I don't consider this to be a showstopper. Will likely open an issue for this at some point.
- The game renders the portal on the opposite side in the dimension being traveled from when the eye has crossed the dimension boundary but the player hasn't (or vice-versa). The actual result of this is effectively a "flash" in your vision during the traversal, or seeing the wrong side of the portal in one eye if you are standing on the boundary.
- Hotswapping out of VR effectively breaks a large amount of rendering. Leaving and re-joining the world fixes this, and hotswapping into VR does not cause the same issue.

What makes this PR so hack-y:
- Mixing into ImmersivePortals probably isn't great, especially with how different their internals can be between versions. These fixes work for Minecraft 1.20.1, but likely will NOT work for Minecraft 1.18.2.

From testing, this does not cause any issues in an environment without ImmersivePortals.

To test this PR, in the `build.gradle` for the modloader, flip the `modCompileOnly` for ImmersivePortals to `modApi`, then add the following lines:
```
modApi("com.github.iPortalTeam:DimLib:v1.0.2-mc1.20.4") {
        exclude(group: "net.fabricmc.fabric-api")
    }
```

If wanted, I can include some or all of these changes in the PR, however they aren't at the moment.