### PR TITLE
Add a printStackTrace to the init vr error so error is actually in the console

### DIFF
--- a/common/src/main/java/org/vivecraft/client_vr/VRState.java
+++ b/common/src/main/java/org/vivecraft/client_vr/VRState.java
@@ -114,6 +114,7 @@ public class VRState {
             vrEnabled = false;
             destroyVR(true);
             Minecraft.getInstance().setScreen(new ErrorScreen(renderConfigException.title, renderConfigException.error));
+            renderConfigException.printStackTrace();
         } catch (Throwable e) {
             vrEnabled = false;
             destroyVR(true);


### PR DESCRIPTION
Was trying to debug an issue and finally caught out why, this one catch didnt print to the console at all! I know it should display an error screen but that doesn't really work in a QuestCraft like environment, hope this helps :D