### PR TITLE
[1.21.4] Immersive Portals Fixes

### DIFF
--- a/common/src/main/java/org/vivecraft/client_vr/gameplay/trackers/TeleportTracker.java
+++ b/common/src/main/java/org/vivecraft/client_vr/gameplay/trackers/TeleportTracker.java
@@ -26,6 +26,7 @@ import org.vivecraft.client_vr.gameplay.VRMovementStyle;
 import org.vivecraft.client_vr.render.helpers.RenderHelper;
 import org.vivecraft.common.utils.MathUtils;
 import org.vivecraft.data.BlockTags;
+import org.vivecraft.mod_compat_vr.immersiveportals.ImmersivePortalsHelper;
 
 import java.util.Random;
 
@@ -304,6 +305,16 @@ public class TeleportTracker implements Tracker {
                     ClipContext.Block.COLLIDER,
                     ClipContext.Fluid.ANY,
                     player));
+
+            if (ImmersivePortalsHelper.isLoaded()) {
+                if (ImmersivePortalsHelper.positionContainsPortalBlock(this.mc.level, newPos)) {
+                    break;
+                }
+                Vec3 lastPos = i == 0 ? null : this.movementTeleportArc[i - 1];
+                if (lastPos != null && ImmersivePortalsHelper.rayIntersectsPortal(this.mc.level, lastPos, newPos)) {
+                    break;
+                }
+            }
 
             if (blockhitresult.getType() != HitResult.Type.MISS) {
                 this.movementTeleportArc[i] = blockhitresult.getLocation();

--- a/common/src/main/java/org/vivecraft/client_vr/render/helpers/VREffectsHelper.java
+++ b/common/src/main/java/org/vivecraft/client_vr/render/helpers/VREffectsHelper.java
@@ -24,6 +24,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.util.profiling.Profiler;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
@@ -95,14 +96,17 @@ public class VREffectsHelper {
      * BlockState and BlockPos of the blocking block
      */
     public static Triple<Float, BlockState, BlockPos> getNearOpaqueBlock(Vec3 pos, double dist) {
-        if (MC.level == null) {
+        // Use player's level, since Immersive Portals likes to set Minecraft#level to be the level the player isn't
+        // necessarily in.
+        Level level = MC.player != null && !MC.player.isRemoved() ? MC.player.level() : MC.level;
+        if (level == null) {
             return null;
         } else {
             AABB aabb = new AABB(pos.subtract(dist, dist, dist), pos.add(dist, dist, dist));
             Stream<BlockPos> stream = BlockPos.betweenClosedStream(aabb).filter((bp) ->
-                MC.level.getBlockState(bp).isSolidRender());
+                level.getBlockState(bp).isSolidRender());
             Optional<BlockPos> optional = stream.findFirst();
-            return optional.map(blockPos -> Triple.of(1.0F, MC.level.getBlockState(blockPos), blockPos)).orElse(null);
+            return optional.map(blockPos -> Triple.of(1.0F, level.getBlockState(blockPos), blockPos)).orElse(null);
         }
     }
 

--- a/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/ImmersivePortalsHelper.java
+++ b/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/ImmersivePortalsHelper.java
@@ -1,7 +1,12 @@
 package org.vivecraft.mod_compat_vr.immersiveportals;
 
 import org.vivecraft.Xloader;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
 import qouteall.imm_ptl.core.IPGlobal;
+import qouteall.imm_ptl.core.IPMcHelper;
+import qouteall.imm_ptl.core.portal.PortalPlaceholderBlock;
 import qouteall.imm_ptl.core.render.context_management.PortalRendering;
 
 public class ImmersivePortalsHelper {
@@ -22,5 +27,13 @@ public class ImmersivePortalsHelper {
      */
     public static boolean shouldRenderSelf() {
         return IPGlobal.renderYourselfInPortal && isRenderingPortal();
+    }
+
+    public static boolean rayIntersectsPortal(Level level, Vec3 start, Vec3 end) {
+        return !IPMcHelper.rayTracePortals(level, start, end, true, p -> true).isEmpty();
+    }
+
+    public static boolean positionContainsPortalBlock(Level level, Vec3 pos) {
+        return level.getBlockState(BlockPos.containing(pos)).is(PortalPlaceholderBlock.instance);
     }
 }

--- a/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/mixin/McHelperMixin.java
+++ b/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/mixin/McHelperMixin.java
@@ -1,0 +1,22 @@
+package org.vivecraft.mod_compat_vr.immersiveportals.mixin;
+
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.vivecraft.client_vr.gameplay.VRPlayer;
+import qouteall.imm_ptl.core.McHelper;
+
+@Mixin(McHelper.class)
+public class McHelperMixin {
+
+    @Inject(method = "updateBoundingBox", at = @At("RETURN"))
+    private static void vivecraft$setRoomOriginOnPortalTeleport(Entity player, CallbackInfo ci) {
+        if (VRPlayer.get() != null) {
+            Vec3 newPos = player.position();
+            VRPlayer.get().setRoomOrigin(newPos.x, newPos.y, newPos.z, true);
+        }
+    }
+}

--- a/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/mixin/McHelperMixin.java
+++ b/common/src/main/java/org/vivecraft/mod_compat_vr/immersiveportals/mixin/McHelperMixin.java
@@ -1,6 +1,9 @@
 package org.vivecraft.mod_compat_vr.immersiveportals.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -12,11 +15,20 @@ import qouteall.imm_ptl.core.McHelper;
 @Mixin(McHelper.class)
 public class McHelperMixin {
 
-    @Inject(method = "updateBoundingBox", at = @At("RETURN"))
-    private static void vivecraft$setRoomOriginOnPortalTeleport(Entity player, CallbackInfo ci) {
-        if (VRPlayer.get() != null) {
-            Vec3 newPos = player.position();
-            VRPlayer.get().setRoomOrigin(newPos.x, newPos.y, newPos.z, true);
+    @WrapMethod(method = "setEyePos")
+    private static void vivecraft$adjustRoomOriginOnEyePosUpdate(Entity entity, Vec3 eyePos, Vec3 lastTickEyePos, Operation<Void> original) {
+        if (entity instanceof Player p && p.isLocalPlayer() && VRPlayer.get() != null) {
+            // Move the room origin after the player portal teleport to be in the same position relative to the player
+            // as before
+            Vec3 oldPos = entity.position();
+            Vec3 oldRoomOrigin = VRPlayer.get().roomOrigin;
+            Vec3 offset = oldRoomOrigin.subtract(oldPos);
+            original.call(entity, eyePos, lastTickEyePos);
+            Vec3 newPos = entity.position();
+            Vec3 newRoomOrigin = newPos.add(offset);
+            VRPlayer.get().setRoomOrigin(newRoomOrigin.x, newRoomOrigin.y, newRoomOrigin.z, true);
+        } else {
+            original.call(entity, eyePos, lastTickEyePos);
         }
     }
 }

--- a/common/src/main/resources/vivecraft.immersiveportals.mixins.json
+++ b/common/src/main/resources/vivecraft.immersiveportals.mixins.json
@@ -1,0 +1,10 @@
+{
+  "required": false,
+  "package": "org.vivecraft.mod_compat_vr.immersiveportals.mixin",
+  "plugin": "org.vivecraft.MixinConfig",
+  "compatibilityLevel": "JAVA_17",
+  "client": [
+    "McHelperMixin"
+  ],
+  "minVersion": "0.8.4"
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -39,6 +39,7 @@
     "vivecraft.cataclysm.mixins.json",
     "vivecraft.dynamicfps.mixins.json",
     "vivecraft.emf.mixins.json",
+    "vivecraft.immersiveportals.mixins.json",
     "vivecraft.iris.mixins.json",
     "vivecraft.mca.mixins.json",
     "vivecraft.modmenu.mixins.json",

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -23,6 +23,7 @@ loom {
         mixinConfig "vivecraft.cataclysm.mixins.json"
         mixinConfig "vivecraft.dynamicfps.mixins.json"
         mixinConfig "vivecraft.emf.mixins.json"
+        mixinConfig "vivecraft.immersiveportals.mixins.json"
         mixinConfig "vivecraft.iris.mixins.json"
         mixinConfig "vivecraft.mca.mixins.json"
         mixinConfig "vivecraft.optifine.mixins.json"

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -54,6 +54,8 @@ config = "vivecraft.dynamicfps.mixins.json"
 [[mixins]]
 config = "vivecraft.emf.mixins.json"
 [[mixins]]
+config = "vivecraft.immersiveportals.mixins.json"
+[[mixins]]
 config = "vivecraft.iris.mixins.json"
 [[mixins]]
 config = "vivecraft.mca.mixins.json"


### PR DESCRIPTION
Fixes two major "show-stopping" bugs with Immersive Portals, making it work far better in Vivecraft than the "doesn't really" it does right now. This fixes two bugs:

- On teleportation, the player would have their sight render in the wrong position due to how the room origin was set in combination with Immersive Portals.
- Fixes the "head stuck in block" effect when rendering an ImmersivePortals portal when the position on the other side of a portal would be a solid block.

A few issues do remain unpatched, however:

- Portals that change player orientation still don't work. Considering the vanilla `/tp` command also can't rotate the player, I don't consider this to be a showstopper. Will likely open an issue for this at some point.
- The game renders the portal on the opposite side in the dimension being traveled from when the eye has crossed the dimension boundary but the player hasn't (or vice-versa). The actual result of this is effectively a "flash" in your vision during the traversal, or seeing the wrong side of the portal in one eye if you are standing on the boundary.
- (new since #256): Some third person types (1st person (slow) and 3rd person so far) when switched to, the game will crash. The game may also crash when hotswitching out of VR, though I'm unsure if it's only in these crash-y modes or for all modes.
- To workaround teleport locomotion across cross-dimensional portals from teleporting the player underground or other odd behaviors, the teleport ray is stopped at portal boundaries.

As this is a port of #256, this does use a mixin into Immersive Portals itself. That said, the area of code mixed into appears to be very stable between Minecraft versions (exists identically in both Immersive Portals for 1.18.2 and for 1.21.1), though long-term, working with the dev team to integrate this properly would be ideal.

This PR can be tested simply by running the 1.21.1 version of this PR. In other words, clone the repository, `git checkout Multiloader-1.21-immersive-portals-fixing` (NOT `Multiloader-1.21.4-immersive-portals-fixing`, as there is no Immersive Portals for 1.21.4), then run via Fabric as usual.

Supersedes #256.