### PR TITLE
Player-Relative Pose History and Index Out of Bounds Fix

### DIFF
--- a/common/src/main/java/org/vivecraft/api/data/VRPoseHistory.java
+++ b/common/src/main/java/org/vivecraft/api/data/VRPoseHistory.java
@@ -11,6 +11,11 @@ import java.util.List;
  * <br>
  * Vivecraft will store data for players going up to 200 ticks into the past. Attempting to retrieve history before
  * this far back will throw an {@link IllegalArgumentException}.
+ * <br>
+ * Many methods in this class accept the parameter {@code playerPositionRelative}. When this is {@code true}, all
+ * calculations are done relative to the player. For example, the net movement of a player who moved from (0, 0, 0)
+ * to (3, 0, 0) but did NOT move their head, hands, etc. would be (3, 0, 0) if {@code playerPositionRelative} is
+ * {@code false} and would be (0, 0, 0) if {@code playerPositionRelative} is {@code true}.
  *
  * @since 1.3.0
  */
@@ -42,7 +47,20 @@ public interface VRPoseHistory {
      * @throws IllegalArgumentException Thrown when {@code ticksBack} is outside the range [0,200].
      * @since 1.3.0
      */
-    VRPose getHistoricalData(int ticksBack) throws IllegalArgumentException;
+    default VRPose getHistoricalData(int ticksBack) throws IllegalArgumentException {
+        return getHistoricalData(ticksBack, false);
+    }
+
+    /**
+     * Gets the pose from {@code ticksBack} ticks back, or {@code null} if such data isn't available.
+     *
+     * @param ticksBack              Ticks back to retrieve data from.
+     * @param playerPositionRelative Whether to get the historical data with position relative to the player's position.
+     * @return A {@link VRPose} instance from {@code ticksBack} ticks ago, or {@code null} if that data isn't available.
+     * @throws IllegalArgumentException Thrown when {@code ticksBack} is outside the range [0,200].
+     * @since 1.3.2
+     */
+    VRPose getHistoricalData(int ticksBack, boolean playerPositionRelative) throws IllegalArgumentException;
 
     /**
      * Gets the net movement between the most recent VRPose in this instance and the oldest VRPose that can be
@@ -57,7 +75,25 @@ public interface VRPoseHistory {
      * @since 1.3.0
      */
     @Nullable
-    Vec3 netMovement(VRBodyPart bodyPart, int maxTicksBack) throws IllegalArgumentException;
+    default Vec3 netMovement(VRBodyPart bodyPart, int maxTicksBack) throws IllegalArgumentException {
+        return netMovement(bodyPart, maxTicksBack, false);
+    }
+
+    /**
+     * Gets the net movement between the most recent VRPose in this instance and the oldest VRPose that can be
+     * retrieved, going no farther back than {@code maxTicksBack}.
+     *
+     * @param bodyPart               The body part to get the net movement for.
+     * @param maxTicksBack           The maximum number of ticks back to compare the most recent data with.
+     * @param playerPositionRelative Whether net movement should be calculated relative to the player position.
+     * @return The aforementioned net movement. Note that this will return zero change on all axes if only zero ticks
+     * can be looked back. Will be {@code null} if the body part requested isn't available.
+     * @throws IllegalArgumentException Thrown when {@code maxTicksBack} is outside the range [0,200] or an invalid
+     *                                  {@code bodyPart} is supplied.
+     * @since 1.3.2
+     */
+    @Nullable
+    Vec3 netMovement(VRBodyPart bodyPart, int maxTicksBack, boolean playerPositionRelative) throws IllegalArgumentException;
 
     /**
      * Gets the average velocity in blocks/tick between the most recent VRPose in this instance and the oldest VRPose
@@ -72,7 +108,25 @@ public interface VRPoseHistory {
      * @since 1.3.0
      */
     @Nullable
-    Vec3 averageVelocity(VRBodyPart bodyPart, int maxTicksBack) throws IllegalArgumentException;
+    default Vec3 averageVelocity(VRBodyPart bodyPart, int maxTicksBack) throws IllegalArgumentException {
+        return averageVelocity(bodyPart, maxTicksBack, false);
+    }
+
+    /**
+     * Gets the average velocity in blocks/tick between the most recent VRPose in this instance and the oldest VRPose
+     * that can be retrieved, going no farther back than {@code maxTicksBack}.
+     *
+     * @param bodyPart               The body part to get the average velocity for.
+     * @param maxTicksBack           The maximum number of ticks back to calculate velocity with.
+     * @param playerPositionRelative Whether velocity should be calculated to the player position.
+     * @return The aforementioned average velocity on each axis. Note that this will return zero velocity on all axes
+     * if only zero ticks can be looked back. Will be {@code null} if the body part requested isn't available.
+     * @throws IllegalArgumentException Thrown when {@code maxTicksBack} is outside the range [0,200] or an invalid
+     *                                  {@code bodyPart} is supplied.
+     * @since 1.3.2
+     */
+    @Nullable
+    Vec3 averageVelocity(VRBodyPart bodyPart, int maxTicksBack, boolean playerPositionRelative) throws IllegalArgumentException;
 
     /**
      * Gets the average speed in blocks/tick between the most recent VRPose in this instance and the oldest VRPose
@@ -86,7 +140,24 @@ public interface VRPoseHistory {
      *                                  {@code bodyPart} is supplied.
      * @since 1.3.0
      */
-    double averageSpeed(VRBodyPart bodyPart, int maxTicksBack) throws IllegalArgumentException;
+    default double averageSpeed(VRBodyPart bodyPart, int maxTicksBack) throws IllegalArgumentException {
+        return averageSpeed(bodyPart, maxTicksBack, false);
+    }
+
+    /**
+     * Gets the average speed in blocks/tick between the most recent VRPose in this instance and the oldest VRPose
+     * that can be retrieved, going no farther back than {@code maxTicksBack}.
+     *
+     * @param bodyPart               The body part to get the average speed for.
+     * @param maxTicksBack           The maximum number of ticks back to calculate speed with.
+     * @param playerPositionRelative Whether the speed should be calculated relative to the player position.
+     * @return The aforementioned average speed on each axis. Note that this will return zero speed if only zero ticks
+     * can be looked back, or if the body part requested isn't available.
+     * @throws IllegalArgumentException Thrown when {@code maxTicksBack} is outside the range [0,200] or an invalid
+     *                                  {@code bodyPart} is supplied.
+     * @since 1.3.2
+     */
+    double averageSpeed(VRBodyPart bodyPart, int maxTicksBack, boolean playerPositionRelative) throws IllegalArgumentException;
 
     /**
      * Gets the average position between the most recent VRPose in this instance and the oldest VRPose that can be
@@ -101,5 +172,23 @@ public interface VRPoseHistory {
      * @since 1.3.0
      */
     @Nullable
-    Vec3 averagePosition(VRBodyPart bodyPart, int maxTicksBack) throws IllegalArgumentException;
+    default Vec3 averagePosition(VRBodyPart bodyPart, int maxTicksBack) throws IllegalArgumentException {
+        return averagePosition(bodyPart, maxTicksBack, false);
+    }
+
+    /**
+     * Gets the average position between the most recent VRPose in this instance and the oldest VRPose that can be
+     * retrieved, going no farther back than {@code maxTicksBack}.
+     *
+     * @param bodyPart               The body part to get the average position for.
+     * @param maxTicksBack           The maximum number of ticks back to calculate the position with.
+     * @param playerPositionRelative Whether the positions should be relative to the player's position.
+     * @return The aforementioned average position. Note that this will return the current position if only zero ticks
+     * can be looked back. Will be {@code null} if the body part requested isn't available.
+     * @throws IllegalArgumentException Thrown when {@code maxTicksBack} is outside the range [0,200] or an invalid
+     *                                  {@code bodyPart} is supplied.
+     * @since 1.3.2
+     */
+    @Nullable
+    Vec3 averagePosition(VRBodyPart bodyPart, int maxTicksBack, boolean playerPositionRelative) throws IllegalArgumentException;
 }

--- a/common/src/main/java/org/vivecraft/api/data/VRPoseHistory.java
+++ b/common/src/main/java/org/vivecraft/api/data/VRPoseHistory.java
@@ -13,9 +13,10 @@ import java.util.List;
  * this far back will throw an {@link IllegalArgumentException}.
  * <br>
  * Many methods in this class accept the parameter {@code playerPositionRelative}. When this is {@code true}, all
- * calculations are done relative to the player. For example, the net movement of a player who moved from (0, 0, 0)
- * to (3, 0, 0) but did NOT move their head, hands, etc. would be (3, 0, 0) if {@code playerPositionRelative} is
- * {@code false} and would be (0, 0, 0) if {@code playerPositionRelative} is {@code true}.
+ * calculations are done relative to the player, while if {@code false}, calculations are done in world space. For
+ * example, the net movement of a player who moved from (0, 0, 0) to (3, 0, 0) but did NOT move their head, hands, etc.
+ * would be (3, 0, 0) if {@code playerPositionRelative} is {@code false} and would be (0, 0, 0) if
+ * {@code playerPositionRelative} is {@code true}.
  *
  * @since 1.3.0
  */
@@ -40,7 +41,7 @@ public interface VRPoseHistory {
     List<VRPose> getAllHistoricalData();
 
     /**
-     * Gets the pose from {@code ticksBack} ticks back, or {@code null} if such data isn't available.
+     * Gets the pose from {@code ticksBack} ticks back in world space, or {@code null} if such data isn't available.
      *
      * @param ticksBack Ticks back to retrieve data from.
      * @return A {@link VRPose} instance from {@code ticksBack} ticks ago, or {@code null} if that data isn't available.
@@ -58,13 +59,13 @@ public interface VRPoseHistory {
      * @param playerPositionRelative Whether to get the historical data with position relative to the player's position.
      * @return A {@link VRPose} instance from {@code ticksBack} ticks ago, or {@code null} if that data isn't available.
      * @throws IllegalArgumentException Thrown when {@code ticksBack} is outside the range [0,200].
-     * @since 1.3.2
+     * @since 1.3.3
      */
     VRPose getHistoricalData(int ticksBack, boolean playerPositionRelative) throws IllegalArgumentException;
 
     /**
-     * Gets the net movement between the most recent VRPose in this instance and the oldest VRPose that can be
-     * retrieved, going no farther back than {@code maxTicksBack}.
+     * Gets the net movement in world space between the most recent VRPose in this instance and the oldest VRPose that
+     * can be retrieved, going no farther back than {@code maxTicksBack}.
      *
      * @param bodyPart     The body part to get the net movement for.
      * @param maxTicksBack The maximum number of ticks back to compare the most recent data with.
@@ -90,14 +91,14 @@ public interface VRPoseHistory {
      * can be looked back. Will be {@code null} if the body part requested isn't available.
      * @throws IllegalArgumentException Thrown when {@code maxTicksBack} is outside the range [0,200] or an invalid
      *                                  {@code bodyPart} is supplied.
-     * @since 1.3.2
+     * @since 1.3.3
      */
     @Nullable
     Vec3 netMovement(VRBodyPart bodyPart, int maxTicksBack, boolean playerPositionRelative) throws IllegalArgumentException;
 
     /**
-     * Gets the average velocity in blocks/tick between the most recent VRPose in this instance and the oldest VRPose
-     * that can be retrieved, going no farther back than {@code maxTicksBack}.
+     * Gets the average velocity in world space in blocks/tick between the most recent VRPose in this instance and the
+     * oldest VRPose that can be retrieved, going no farther back than {@code maxTicksBack}.
      *
      * @param bodyPart     The body part to get the average velocity for.
      * @param maxTicksBack The maximum number of ticks back to calculate velocity with.
@@ -123,14 +124,14 @@ public interface VRPoseHistory {
      * if only zero ticks can be looked back. Will be {@code null} if the body part requested isn't available.
      * @throws IllegalArgumentException Thrown when {@code maxTicksBack} is outside the range [0,200] or an invalid
      *                                  {@code bodyPart} is supplied.
-     * @since 1.3.2
+     * @since 1.3.3
      */
     @Nullable
     Vec3 averageVelocity(VRBodyPart bodyPart, int maxTicksBack, boolean playerPositionRelative) throws IllegalArgumentException;
 
     /**
-     * Gets the average speed in blocks/tick between the most recent VRPose in this instance and the oldest VRPose
-     * that can be retrieved, going no farther back than {@code maxTicksBack}.
+     * Gets the average speed in world space in blocks/tick between the most recent VRPose in this instance and the
+     * oldest VRPose that can be retrieved, going no farther back than {@code maxTicksBack}.
      *
      * @param bodyPart     The body part to get the average speed for.
      * @param maxTicksBack The maximum number of ticks back to calculate speed with.
@@ -155,13 +156,13 @@ public interface VRPoseHistory {
      * can be looked back, or if the body part requested isn't available.
      * @throws IllegalArgumentException Thrown when {@code maxTicksBack} is outside the range [0,200] or an invalid
      *                                  {@code bodyPart} is supplied.
-     * @since 1.3.2
+     * @since 1.3.3
      */
     double averageSpeed(VRBodyPart bodyPart, int maxTicksBack, boolean playerPositionRelative) throws IllegalArgumentException;
 
     /**
-     * Gets the average position between the most recent VRPose in this instance and the oldest VRPose that can be
-     * retrieved, going no farther back than {@code maxTicksBack}.
+     * Gets the average position in world space between the most recent VRPose in this instance and the oldest VRPose
+     * that can be retrieved, going no farther back than {@code maxTicksBack}.
      *
      * @param bodyPart     The body part to get the average position for.
      * @param maxTicksBack The maximum number of ticks back to calculate the position with.
@@ -187,7 +188,7 @@ public interface VRPoseHistory {
      * can be looked back. Will be {@code null} if the body part requested isn't available.
      * @throws IllegalArgumentException Thrown when {@code maxTicksBack} is outside the range [0,200] or an invalid
      *                                  {@code bodyPart} is supplied.
-     * @since 1.3.2
+     * @since 1.3.3
      */
     @Nullable
     Vec3 averagePosition(VRBodyPart bodyPart, int maxTicksBack, boolean playerPositionRelative) throws IllegalArgumentException;

--- a/common/src/main/java/org/vivecraft/client/ClientVRPlayers.java
+++ b/common/src/main/java/org/vivecraft/client/ClientVRPlayers.java
@@ -199,7 +199,7 @@ public class ClientVRPlayers {
         if (!localPlayer) {
             Player otherPlayer = this.mc.level.getPlayerByUUID(uuid);
             if (otherPlayer != null) {
-                VRAPIImpl.INSTANCE.addPoseToHistory(uuid, rotInfo.asVRPose(otherPlayer.position()), true);
+                VRAPIImpl.INSTANCE.addPoseToHistory(uuid, rotInfo.asVRPose(otherPlayer.position()), otherPlayer.position(), true);
             }
         }
 

--- a/common/src/main/java/org/vivecraft/client/api_impl/VRClientAPIImpl.java
+++ b/common/src/main/java/org/vivecraft/client/api_impl/VRClientAPIImpl.java
@@ -1,5 +1,6 @@
 package org.vivecraft.client.api_impl;
 
+import net.minecraft.world.phys.Vec3;
 import org.vivecraft.api.client.VRClientAPI;
 import org.vivecraft.api.client.data.CloseKeyboardContext;
 import org.vivecraft.api.client.data.OpenKeyboardContext;
@@ -34,8 +35,8 @@ public final class VRClientAPIImpl implements VRClientAPI {
         this.poseHistory.clear();
     }
 
-    public void addPoseToHistory(VRPose pose) {
-        this.poseHistory.addPose(pose);
+    public void addPoseToHistory(VRPose pose, Vec3 playerPos) {
+        this.poseHistory.addPose(pose, playerPos);
     }
 
     public void processRegistrationEvent() {

--- a/common/src/main/java/org/vivecraft/client_vr/gameplay/VRPlayer.java
+++ b/common/src/main/java/org/vivecraft/client_vr/gameplay/VRPlayer.java
@@ -240,7 +240,7 @@ public class VRPlayer {
         if (this.mc.level != null &&
             (this.mc.getSingleplayerServer() == null || !this.mc.getSingleplayerServer().isPaused()))
         {
-            VRClientAPIImpl.INSTANCE.addPoseToHistory(this.vrdata_world_pre.asVRPose());
+            VRClientAPIImpl.INSTANCE.addPoseToHistory(this.vrdata_world_pre.asVRPose(), this.mc.player.position());
         }
     }
 

--- a/common/src/main/java/org/vivecraft/common/api_impl/VRAPIImpl.java
+++ b/common/src/main/java/org/vivecraft/common/api_impl/VRAPIImpl.java
@@ -2,6 +2,7 @@ package org.vivecraft.common.api_impl;
 
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.phys.Vec3;
 import org.vivecraft.api.VRAPI;
 import org.vivecraft.api.data.VRPose;
 import org.vivecraft.api.data.VRPoseHistory;
@@ -30,14 +31,14 @@ public final class VRAPIImpl implements VRAPI {
         this.getMap(isClientSide).remove(player);
     }
 
-    public void addPoseToHistory(UUID player, VRPose pose, boolean isClientSide) {
+    public void addPoseToHistory(UUID player, VRPose pose, Vec3 playerPos, boolean isClientSide) {
         Map<UUID, VRPoseHistoryImpl> poseHistories = this.getMap(isClientSide);
         VRPoseHistoryImpl poseHistory = poseHistories.get(player);
         if (poseHistory == null) {
             poseHistory = new VRPoseHistoryImpl();
             poseHistories.put(player, poseHistory);
         }
-        poseHistory.addPose(pose);
+        poseHistory.addPose(pose, playerPos);
     }
 
     public void clearAllPoseHistories() {

--- a/common/src/main/java/org/vivecraft/common/api_impl/data/VRPoseHistoryImpl.java
+++ b/common/src/main/java/org/vivecraft/common/api_impl/data/VRPoseHistoryImpl.java
@@ -7,6 +7,7 @@ import org.vivecraft.api.data.VRPose;
 import org.vivecraft.api.data.VRPoseHistory;
 import org.vivecraft.common.api_impl.VRAPIImpl;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -15,12 +16,12 @@ public class VRPoseHistoryImpl implements VRPoseHistory {
 
     // Holds historical VRPose data. The index into here is simply the number of ticks back that data is, with index
     // 0 being 0 ticks back.
-    private final LinkedList<VRPose> dataQueue = new LinkedList<>();
+    private final LinkedList<PoseData> dataQueue = new LinkedList<>();
 
     public VRPoseHistoryImpl() {}
 
-    public void addPose(VRPose pose) {
-        this.dataQueue.addFirst(pose);
+    public void addPose(VRPose pose, Vec3 playerPos) {
+        this.dataQueue.addFirst(new PoseData(pose, playerPos));
         // + 1 here since index 0 is 0 ticks back.
         if (this.dataQueue.size() > VRAPIImpl.MAX_HISTORY_TICKS + 1) {
             this.dataQueue.removeLast();
@@ -42,40 +43,38 @@ public class VRPoseHistoryImpl implements VRPoseHistory {
 
     @Override
     public List<VRPose> getAllHistoricalData() {
-        return List.copyOf(this.dataQueue);
+        return this.dataQueue.stream().map(PoseData::pose).toList();
     }
 
     @Override
-    public VRPose getHistoricalData(int ticksBack) throws IllegalArgumentException {
+    public VRPose getHistoricalData(int ticksBack, boolean playerPositionRelative) throws IllegalArgumentException {
         checkTicksBack(ticksBack);
         if (this.dataQueue.size() <= ticksBack) {
             return null;
         }
-        return this.dataQueue.get(ticksBack);
+        return this.dataQueue.get(ticksBack).getPose(playerPositionRelative);
     }
 
     @Override
-    public Vec3 netMovement(VRBodyPart bodyPart, int maxTicksBack) throws IllegalArgumentException {
+    public Vec3 netMovement(VRBodyPart bodyPart, int maxTicksBack, boolean playerPositionRelative) throws IllegalArgumentException {
         checkPartNonNull(bodyPart);
         checkTicksBack(maxTicksBack);
         if (this.dataQueue.size() <= 1) {
             return Vec3.ZERO;
         }
-        VRBodyPartData currentData = this.dataQueue.getFirst().getBodyPartData(bodyPart);
-        if (currentData == null) {
+        Vec3 current = this.dataQueue.getFirst().getPos(bodyPart, playerPositionRelative);
+        if (current == null) {
             return null;
         }
-        Vec3 current = currentData.getPos();
-        VRBodyPartData oldData = this.dataQueue.get(maxTicksBack).getBodyPartData(bodyPart);
-        if (oldData == null) {
+        Vec3 old = this.dataQueue.get(maxTicksBack).getPos(bodyPart, playerPositionRelative);
+        if (old == null) {
             return null;
         }
-        Vec3 old = oldData.getPos();
         return current.subtract(old);
     }
 
     @Override
-    public Vec3 averageVelocity(VRBodyPart bodyPart, int maxTicksBack) throws IllegalArgumentException {
+    public Vec3 averageVelocity(VRBodyPart bodyPart, int maxTicksBack, boolean playerPositionRelative) throws IllegalArgumentException {
         checkPartNonNull(bodyPart);
         checkTicksBack(maxTicksBack);
         if (this.dataQueue.size() <= 1) {
@@ -83,18 +82,18 @@ public class VRPoseHistoryImpl implements VRPoseHistory {
         }
         maxTicksBack = getNumTicksBack(maxTicksBack);
         List<Vec3> diffs = new ArrayList<>(maxTicksBack);
-        for (int i = 0; i <= maxTicksBack; i++) {
-            VRBodyPartData newer = this.dataQueue.get(i).getBodyPartData(bodyPart);
-            VRBodyPartData older = this.dataQueue.get(i + 1).getBodyPartData(bodyPart);
+        for (int i = 0; i < maxTicksBack; i++) {
+            Vec3 newer = this.dataQueue.get(i).getPos(bodyPart, playerPositionRelative);
+            Vec3 older = this.dataQueue.get(i + 1).getPos(bodyPart, playerPositionRelative);
             if (newer == null || older == null) {
                 break;
             }
-            diffs.add(newer.getPos().subtract(older.getPos()));
+            diffs.add(newer.subtract(older));
         }
         if (diffs.isEmpty()) {
             // Return no change if the body part is available but no historical data or null if body part isn't
             // available.
-            return this.dataQueue.getFirst().getBodyPartData(bodyPart) != null ? Vec3.ZERO : null;
+            return this.dataQueue.getFirst().pose.getBodyPartData(bodyPart) != null ? Vec3.ZERO : null;
         }
         return new Vec3(
             diffs.stream().mapToDouble(vec -> vec.x).average().orElse(0),
@@ -104,7 +103,7 @@ public class VRPoseHistoryImpl implements VRPoseHistory {
     }
 
     @Override
-    public double averageSpeed(VRBodyPart bodyPart, int maxTicksBack) throws IllegalArgumentException {
+    public double averageSpeed(VRBodyPart bodyPart, int maxTicksBack, boolean playerPositionRelative) throws IllegalArgumentException {
         checkPartNonNull(bodyPart);
         checkTicksBack(maxTicksBack);
         if (this.dataQueue.size() <= 1) {
@@ -112,19 +111,19 @@ public class VRPoseHistoryImpl implements VRPoseHistory {
         }
         maxTicksBack = getNumTicksBack(maxTicksBack);
         List<Double> speeds = new ArrayList<>(maxTicksBack);
-        for (int i = 0; i <= maxTicksBack; i++) {
-            VRBodyPartData newer = this.dataQueue.get(i).getBodyPartData(bodyPart);
-            VRBodyPartData older = this.dataQueue.get(i + 1).getBodyPartData(bodyPart);
+        for (int i = 0; i < maxTicksBack; i++) {
+            Vec3 newer = this.dataQueue.get(i).getPos(bodyPart, playerPositionRelative);
+            Vec3 older = this.dataQueue.get(i + 1).getPos(bodyPart, playerPositionRelative);
             if (newer == null || older == null) {
                 break;
             }
-            speeds.add(newer.getPos().distanceTo(older.getPos()));
+            speeds.add(newer.distanceTo(older));
         }
         return speeds.stream().mapToDouble(Double::valueOf).average().orElse(0);
     }
 
     @Override
-    public Vec3 averagePosition(VRBodyPart bodyPart, int maxTicksBack) throws IllegalArgumentException {
+    public Vec3 averagePosition(VRBodyPart bodyPart, int maxTicksBack, boolean playerPositionRelative) throws IllegalArgumentException {
         checkPartNonNull(bodyPart);
         checkTicksBack(maxTicksBack);
         if (this.dataQueue.isEmpty()) {
@@ -133,12 +132,12 @@ public class VRPoseHistoryImpl implements VRPoseHistory {
         maxTicksBack = getNumTicksBack(maxTicksBack);
         List<Vec3> positions = new ArrayList<>(maxTicksBack);
         int i = 0;
-        for (VRPose pose : this.dataQueue) {
-            VRBodyPartData data = pose.getBodyPartData(bodyPart);
-            if (data == null) {
+        for (PoseData poseData : this.dataQueue) {
+            Vec3 pos = poseData.getPos(bodyPart, playerPositionRelative);
+            if (pos == null) {
                 break;
             }
-            positions.add(data.getPos());
+            positions.add(pos);
             if (++i >= maxTicksBack) break;
         }
         if (positions.isEmpty()) {
@@ -168,6 +167,26 @@ public class VRPoseHistoryImpl implements VRPoseHistory {
             return this.dataQueue.size() - 1;
         } else {
             return maxTicksBack;
+        }
+    }
+
+    private record PoseData(VRPose pose, Vec3 playerPosition) {
+        @Nullable
+        public Vec3 getPos(VRBodyPart vrBodyPart, boolean playerPositionRelative) {
+            VRBodyPartData vrBodyPartData = pose.getBodyPartData(vrBodyPart);
+            if (vrBodyPartData == null) {
+                return null;
+            } else if (playerPositionRelative) {
+                return vrBodyPartData.getPos().subtract(playerPosition);
+            }
+            return vrBodyPartData.getPos();
+        }
+
+        public VRPose getPose(boolean playerPositionRelative) {
+            if (playerPositionRelative) {
+                return ((VRPoseImpl) pose).relativeToPosition(playerPosition);
+            }
+            return pose;
         }
     }
 }

--- a/common/src/main/java/org/vivecraft/common/api_impl/data/VRPoseImpl.java
+++ b/common/src/main/java/org/vivecraft/common/api_impl/data/VRPoseImpl.java
@@ -1,5 +1,6 @@
 package org.vivecraft.common.api_impl.data;
 
+import net.minecraft.world.phys.Vec3;
 import org.vivecraft.api.data.FBTMode;
 import org.vivecraft.api.data.VRBodyPart;
 import org.vivecraft.api.data.VRBodyPartData;
@@ -38,6 +39,24 @@ public record VRPoseImpl(VRBodyPartData hmd, VRBodyPartData c0, VRBodyPartData c
     @Override
     public FBTMode getFBTMode() {
         return this.fbtMode;
+    }
+
+    public VRPoseImpl relativeToPosition(Vec3 position) {
+        return new VRPoseImpl(
+            relativeToPosition(hmd, position), relativeToPosition(c0, position), relativeToPosition(c1, position),
+            relativeToPosition(rightFoot, position), relativeToPosition(leftFoot, position),
+            relativeToPosition(waist, position),
+            relativeToPosition(rightKnee, position), relativeToPosition(leftKnee, position),
+            relativeToPosition(rightElbow, position), relativeToPosition(leftElbow, position),
+            isSeated, isLeftHanded, fbtMode
+        );
+    }
+
+    private VRBodyPartData relativeToPosition(VRBodyPartData vrBodyPartData, Vec3 position) {
+        if (vrBodyPartData == null) {
+            return null;
+        }
+        return new VRBodyPartDataImpl(vrBodyPartData.getPos().subtract(position), vrBodyPartData.getDir(), vrBodyPartData.getRotation());
     }
 
     @Override

--- a/common/src/main/java/org/vivecraft/server/ServerVivePlayer.java
+++ b/common/src/main/java/org/vivecraft/server/ServerVivePlayer.java
@@ -207,7 +207,7 @@ public class ServerVivePlayer {
         this.vrPlayerState = vrPlayerState;
         this.vrPlayerStateAsPose = null;
         VRAPIImpl.INSTANCE.addPoseToHistory(this.player.getUUID(), vrPlayerState.asVRPose(this.player.position()),
-            false);
+            this.player.position(), false);
     }
 
     public VRPose asVRPose() {


### PR DESCRIPTION
Adds player-relative pose history by adding versions of the new methods that take the same parameters and have the same names as the old, but adds an extra `boolean` for if things should be done player-relative or not. Original methods are now `default` methods in the interface, which from bytecode comparison looks like shouldn't break ABI, but I haven't actually tested that yet.

This also fixes an out of bounds index in `averageVelocity()` and `averageSpeed()` since the upper-bound for the `for` loop was wrong.