### PR TITLE
VRAPI#getVRPose() Fixes and VRRenderingAPI#getWorldRenderPose()

### DIFF
--- a/common/src/main/java/org/vivecraft/api/client/VRRenderingAPI.java
+++ b/common/src/main/java/org/vivecraft/api/client/VRRenderingAPI.java
@@ -2,11 +2,14 @@ package org.vivecraft.api.client;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Matrix4f;
 import org.vivecraft.api.client.data.RenderPass;
 import org.vivecraft.api.data.VRPose;
 import org.vivecraft.client.api_impl.VRRenderingAPIImpl;
+
+import javax.annotation.Nullable;
 
 /**
  * The main interface for interacting with Vivecraft from rendering code. For other client-side code, one should use
@@ -93,4 +96,15 @@ public interface VRRenderingAPI {
      * @since Minecraft 1.20.5
      */
     void setupRenderingAtHand(InteractionHand hand, Matrix4f matrix);
+
+    /**
+     * Gets the VR pose representing the player in Minecraft world coordinates interpolated for rendering.
+     *
+     * @param player Player to get the VR pose interpolated for rendering of.
+     * @return The VR pose representing the provided player in Minecraft space post-tick interpolated for rendering, or
+     * {@code null} if the local player isn't in VR.
+     * @since 1.3.5
+     */
+    @Nullable
+    VRPose getWorldRenderPose(Player player);
 }

--- a/common/src/main/java/org/vivecraft/api/client/VRRenderingAPI.java
+++ b/common/src/main/java/org/vivecraft/api/client/VRRenderingAPI.java
@@ -102,7 +102,7 @@ public interface VRRenderingAPI {
      *
      * @param player Player to get the VR pose interpolated for rendering of.
      * @return The VR pose representing the provided player in Minecraft space post-tick interpolated for rendering, or
-     * {@code null} if the local player isn't in VR.
+     * {@code null} if the player isn't in VR.
      * @since 1.3.5
      */
     @Nullable

--- a/common/src/main/java/org/vivecraft/client/api_impl/VRRenderingAPIImpl.java
+++ b/common/src/main/java/org/vivecraft/client/api_impl/VRRenderingAPIImpl.java
@@ -3,10 +3,14 @@ package org.vivecraft.client.api_impl;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix4f;
 import org.vivecraft.api.client.VRRenderingAPI;
 import org.vivecraft.api.client.data.RenderPass;
+import org.vivecraft.api.data.VRPose;
+import org.vivecraft.client.ClientVRPlayers;
 import org.vivecraft.client_vr.ClientDataHolderVR;
 import org.vivecraft.client_vr.VRState;
 import org.vivecraft.client_vr.render.helpers.RenderHelper;
@@ -56,5 +60,14 @@ public class VRRenderingAPIImpl implements VRRenderingAPI {
     @Override
     public void setupRenderingAtHand(InteractionHand hand, Matrix4f matrix) {
         RenderHelper.setupRenderingAtController(hand.ordinal(), matrix);
+    }
+
+    @Override
+    public @Nullable VRPose getWorldRenderPose(Player player) {
+        if (player.isLocalPlayer()) {
+            return VRClientAPIImpl.INSTANCE.getWorldRenderPose();
+        } else {
+            return ClientVRPlayers.getInstance().getRotationsForPlayer(player.getUUID()).asVRPose(player.position());
+        }
     }
 }

--- a/common/src/main/java/org/vivecraft/client/api_impl/VRRenderingAPIImpl.java
+++ b/common/src/main/java/org/vivecraft/client/api_impl/VRRenderingAPIImpl.java
@@ -5,7 +5,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.Vec3;
-import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix4f;
 import org.vivecraft.api.client.VRRenderingAPI;
 import org.vivecraft.api.client.data.RenderPass;
@@ -15,6 +14,8 @@ import org.vivecraft.client_vr.ClientDataHolderVR;
 import org.vivecraft.client_vr.VRState;
 import org.vivecraft.client_vr.render.helpers.RenderHelper;
 import org.vivecraft.client_xr.render_pass.RenderPassType;
+
+import javax.annotation.Nullable;
 
 public class VRRenderingAPIImpl implements VRRenderingAPI {
 
@@ -63,7 +64,8 @@ public class VRRenderingAPIImpl implements VRRenderingAPI {
     }
 
     @Override
-    public @Nullable VRPose getWorldRenderPose(Player player) {
+    @Nullable
+    public VRPose getWorldRenderPose(Player player) {
         if (player.isLocalPlayer()) {
             return VRClientAPIImpl.INSTANCE.getWorldRenderPose();
         } else {

--- a/common/src/main/java/org/vivecraft/common/api_impl/VRAPIImpl.java
+++ b/common/src/main/java/org/vivecraft/common/api_impl/VRAPIImpl.java
@@ -66,7 +66,8 @@ public final class VRAPIImpl implements VRAPI {
         } else if (player.isLocalPlayer()) {
             return VRClientAPIImpl.INSTANCE.getPreTickWorldPose();
         } else {
-            return ClientVRPlayers.getInstance().getLatestRotationsForPlayer(player.getUUID()).asVRPose(player.position());
+            return ClientVRPlayers.getInstance().getLatestRotationsForPlayer(player.getUUID())
+                .asVRPose(player.position());
         }
     }
 

--- a/common/src/main/java/org/vivecraft/common/api_impl/VRAPIImpl.java
+++ b/common/src/main/java/org/vivecraft/common/api_impl/VRAPIImpl.java
@@ -63,8 +63,10 @@ public final class VRAPIImpl implements VRAPI {
             return null;
         } else if (player instanceof ServerPlayer serverPlayer) {
             return ServerVRPlayers.getVivePlayer(serverPlayer).asVRPose();
+        } else if (player.isLocalPlayer()) {
+            return VRClientAPIImpl.INSTANCE.getPreTickWorldPose();
         } else {
-            return ClientVRPlayers.getInstance().getRotationsForPlayer(player.getUUID()).asVRPose(player.position());
+            return ClientVRPlayers.getInstance().getLatestRotationsForPlayer(player.getUUID()).asVRPose(player.position());
         }
     }
 


### PR DESCRIPTION
Makes the following changes:

- Fixes `VRAPI#getVRPose()` to provide tick-related data, rather than interpolated data for rendering.
    - This fixes a crash when switching into VR while in the world, where rendering data wouldn't be available, thus causing this to crash when getting data for the local player.
- Added `VRRenderingAPI#getWorldRenderPose()` to get the interpolated render pose for both the local player (duplicating the functionality of `VRClientAPI#getWorldRenderPose()`) and remote players.