### PR TITLE
Submit eyes before processing other passes.

### DIFF
--- a/common/src/main/java/org/vivecraft/client_vr/provider/MCVR.java
+++ b/common/src/main/java/org/vivecraft/client_vr/provider/MCVR.java
@@ -216,6 +216,8 @@ public abstract class MCVR<T extends InputAction> {
         ME = null;
     }
 
+    public void prerender() {}
+
     /**
      * triggers a haptic pulse on the give controller, as soon as possible
      *

--- a/common/src/main/java/org/vivecraft/client_vr/provider/openxr/OpenXRStereoRenderer.java
+++ b/common/src/main/java/org/vivecraft/client_vr/provider/openxr/OpenXRStereoRenderer.java
@@ -2,6 +2,7 @@ package org.vivecraft.client_vr.provider.openxr;
 
 import com.mojang.blaze3d.pipeline.RenderTarget;
 import net.minecraft.util.Tuple;
+import net.minecraft.util.profiling.Profiler;
 import org.joml.Matrix4f;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.openxr.*;
@@ -19,7 +20,6 @@ public class OpenXRStereoRenderer extends VRRenderer {
     private int swapIndex;
     private VRLayeredRenderTarget[] leftFramebuffers;
     private VRLayeredRenderTarget[] rightFramebuffers;
-    private boolean render;
     private XrCompositionLayerProjectionView.Buffer projectionLayerViews;
     private boolean recalculateProjectionMatrix = true;
 
@@ -70,7 +70,7 @@ public class OpenXRStereoRenderer extends VRRenderer {
     public void setupRenderConfiguration(boolean render) throws IOException, RenderConfigException {
         super.setupRenderConfiguration(render);
 
-        if (!render) return;
+        if(!render) return;
 
         this.projectionLayerViews = XrCompositionLayerProjectionView.calloc(2);
         try (MemoryStack stack = MemoryStack.stackPush()) {

--- a/common/src/main/java/org/vivecraft/client_vr/render/helpers/VRPassHelper.java
+++ b/common/src/main/java/org/vivecraft/client_vr/render/helpers/VRPassHelper.java
@@ -211,26 +211,28 @@ public class VRPassHelper {
             }
 
             DATA_HOLDER.isFirstPass = false;
-        }
-        // now we are done with rendering
-        Profiler.get().pop();
 
+            // Submit the frame immediately after eyes are done
+            if(renderpass == RenderPass.RIGHT) {
+                Profiler.get().push("vrMirror");
+                // use the vanilla target for the mirror
+                RenderPassManager.setMirrorRenderPass();
+                ShaderHelper.drawMirror();
+                RenderHelper.checkGLError("post-mirror");
+
+                Profiler.get().popPush("Display/Reproject");
+                try {
+                    DATA_HOLDER.vrRenderer.endFrame();
+                } catch (RenderConfigException exception) {
+                    VRSettings.LOGGER.error("Vivecraft: error ending frame: {}", exception.error.getString());
+                }
+                Profiler.get().pop();
+                RenderHelper.checkGLError("post submit");
+            }
+        }
         DATA_HOLDER.vrPlayer.postRender(deltaTracker.getGameTimeDeltaPartialTick(true));
 
-        Profiler.get().push("vrMirror");
-        // use the vanilla target for the mirror
-        RenderPassManager.setMirrorRenderPass();
-        ShaderHelper.drawMirror();
-        RenderHelper.checkGLError("post-mirror");
-
-        Profiler.get().popPush("Display/Reproject");
-
-        try {
-            DATA_HOLDER.vrRenderer.endFrame();
-        } catch (RenderConfigException exception) {
-            VRSettings.LOGGER.error("Vivecraft: error ending frame: {}", exception.error.getString());
-        }
+        // now we are done with rendering
         Profiler.get().pop();
-        RenderHelper.checkGLError("post submit");
     }
 }

--- a/common/src/main/java/org/vivecraft/mixin/client_vr/MinecraftVRMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/client_vr/MinecraftVRMixin.java
@@ -211,23 +211,6 @@ public abstract class MinecraftVRMixin implements MinecraftExtension {
             // switch vr in the menu, or when allowed by the server
             vivecraft$switchVRState(vrActive);
         }
-        if (VRState.VR_RUNNING) {
-            ClientDataHolderVR.getInstance().frameIndex++;
-            RenderPassManager.setGUIRenderPass();
-            // reset camera position, if there is one, since it only gets set at the start of rendering, and the last renderpass can be anywhere
-            if (this.gameRenderer != null && this.gameRenderer.getMainCamera() != null && this.level != null &&
-                this.getCameraEntity() != null)
-            {
-                this.gameRenderer.getMainCamera().setup(this.level, this.getCameraEntity(), false, false,
-                    this.level.tickRateManager().isEntityFrozen(this.getCameraEntity()) ? 1.0f :
-                        this.deltaTracker.getGameTimeDeltaPartialTick(true));
-            }
-
-            Profiler.get().push("VR Poll/VSync");
-            ClientDataHolderVR.getInstance().vr.poll(ClientDataHolderVR.getInstance().frameIndex);
-            Profiler.get().pop();
-            ClientDataHolderVR.getInstance().vrPlayer.postPoll();
-        }
     }
 
     @Inject(method = "runTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Minecraft;tick()V"))
@@ -257,6 +240,22 @@ public abstract class MinecraftVRMixin implements MinecraftExtension {
     @Inject(method = "runTick", at = @At(value = "CONSTANT", args = "stringValue=render"))
     private void vivecraft$preRender(CallbackInfo ci) {
         if (VRState.VR_RUNNING) {
+            ClientDataHolderVR.getInstance().frameIndex++;
+            RenderPassManager.setGUIRenderPass();
+            // reset camera position, if there is one, since it only gets set at the start of rendering, and the last renderpass can be anywhere
+            if (this.gameRenderer != null && this.gameRenderer.getMainCamera() != null && this.level != null &&
+                this.getCameraEntity() != null)
+            {
+                this.gameRenderer.getMainCamera().setup(this.level, this.getCameraEntity(), false, false,
+                    this.level.tickRateManager().isEntityFrozen(this.getCameraEntity()) ? 1.0f :
+                        this.deltaTracker.getGameTimeDeltaPartialTick(true));
+            }
+
+            Profiler.get().push("VR Poll/VSync");
+            ClientDataHolderVR.getInstance().vr.poll(ClientDataHolderVR.getInstance().frameIndex);
+            Profiler.get().pop();
+            ClientDataHolderVR.getInstance().vrPlayer.postPoll();
+
             Profiler.get().push("preRender");
             ClientDataHolderVR.getInstance().vrPlayer.preRender(this.deltaTracker.getGameTimeDeltaPartialTick(true));
             VRHotkeys.updateMovingThirdPersonCam();
@@ -266,6 +265,8 @@ public abstract class MinecraftVRMixin implements MinecraftExtension {
 
     @ModifyArg(method = "runTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/GameRenderer;render(Lnet/minecraft/client/DeltaTracker;Z)V"))
     private boolean vivecraft$setupRenderGUI(boolean renderLevel) {
+        Profiler.get().popPush("updatePose/Vsync");
+
         if (VRState.VR_RUNNING) {
             try {
                 Profiler.get().push("setupRenderConfiguration");


### PR DESCRIPTION
Some XR runtimes, such as Meta, can utilize the eyes in parallel with the application. Make them available sooner for a decent FPS boost for said runtimes.