### PR TITLE
Null Check for vivePlayer in damageModifier

### DIFF
--- a/common/src/main/java/org/vivecraft/mixin/server/ServerPlayerMixin.java
+++ b/common/src/main/java/org/vivecraft/mixin/server/ServerPlayerMixin.java
@@ -130,7 +130,7 @@ public abstract class ServerPlayerMixin extends PlayerMixin {
         // feet make more damage with boots
         if (ServerConfig.DUAL_WIELDING.get() && ServerConfig.BOOTS_ARMOR_DAMAGE.get() > 0) {
             ServerVivePlayer vivePlayer = vivecraft$getVivePlayer();
-            if (vivePlayer.isVR() && vivePlayer.activeBodyPart.isFoot() &&
+            if (vivePlayer != null && vivePlayer.isVR() && vivePlayer.activeBodyPart.isFoot() &&
                 !this.getItemBySlot(EquipmentSlot.FEET).isEmpty())
             {
                 float addedDamage = 0F;


### PR DESCRIPTION
Add null check for vivePlayer in damageModifier in case player isn't ServerVivePlayer (Such as for bedrock players connected through geyser)