### PR TITLE
catch block swallows the exception

### DIFF
--- a/common/src/main/java/org/vivecraft/client_vr/menuworlds/MenuWorldRenderer.java
+++ b/common/src/main/java/org/vivecraft/client_vr/menuworlds/MenuWorldRenderer.java
@@ -886,7 +886,9 @@ public class MenuWorldRenderer {
             try {
                 sunriseColor = this.getValue(EnvironmentAttributes.SUNRISE_SUNSET_COLOR,
                     ClientUtils.getCurrentPartialTick()); // calcSunriseSunsetColors
-            } catch (Exception ignore) {}
+            } catch (Exception e) {
+                VRSettings.LOGGER.warn("Vivecraft: MenuWorlds: Failed to get sunrise/sunset color", e);
+            }
 
             MultiBufferSource.BufferSource bufferSource = this.mc.renderBuffers().bufferSource();
 
@@ -1828,7 +1830,9 @@ public class MenuWorldRenderer {
                     try {
                         sunriseColor = this.menuWorldRenderer.getValue(EnvironmentAttributes.SUNRISE_SUNSET_COLOR,
                             ClientUtils.getCurrentPartialTick());
-                    } catch (Exception ignore) {}
+                    } catch (Exception e) {
+                        VRSettings.LOGGER.warn("Vivecraft: MenuWorlds: Failed to get sunrise/sunset color", e);
+                    }
 
                     if (ARGB.alphaFloat(sunriseColor) > 0) {
                         f5 = f5 * ARGB.alphaFloat(sunriseColor);


### PR DESCRIPTION
Not sure how often MenuWorldRenderer hits the edge case, but If this path fails, the code keeps going without any signal. This patch tightens the code around that spot. Close this if it’s not worth the noise.
Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.